### PR TITLE
Add ellipse and elliptic cylinder to the path and mesh respectively

### DIFF
--- a/Sources/Shapes.swift
+++ b/Sources/Shapes.swift
@@ -47,6 +47,17 @@ public extension Path {
         return Path(unchecked: points, plane: .xy)
     }
 
+    /// Create a closed elliptical path
+    static func ellipse(width: Double, height: Double, segments: Int = 16) -> Path {
+        var points = [PathPoint]()
+        let halfWidth = width * 0.5
+        let halfHeight = height * 0.5
+        for angle: Double in stride(from: 0, through: .pi * 2, by: .pi * 2 / Double(segments)) {
+            points.append(.curve(halfWidth * cos(angle), halfHeight * sin(angle)))
+        }
+        return Path(unchecked: points, plane: .xy)
+    }
+
     /// Create a closed rectangular path
     static func rectangle(width: Double, height: Double) -> Path {
         let w = width / 2, h = height / 2
@@ -289,6 +300,23 @@ public extension Mesh {
             wrapMode: wrapMode,
             material: material
         )
+    }
+
+    static func ellipticCylinder(width: Double = 1,
+                                 depth: Double = 2,
+                                 height: Double = 1,
+                                 segments: Int = 16,
+                                 poleDetail: Int = 0,
+                                 faces: Faces = .default,
+                                 material: Polygon.Material = nil) -> Mesh {
+        return extrude(
+            Path.ellipse(width: width,
+                     height: depth,
+                     segments: segments)
+                .rotated(by: Rotation(pitch: .pi/2)),
+            depth: height,
+            faces: faces,
+            material: material)
     }
 
     /// Construct as conical mesh


### PR DESCRIPTION
This adds a convince functions to create both 2D ellipse and 3D elliptic cylinder (which is essentially an extrusion of the ellipse with given height)

I tried to maintain the existent code style but might have missed something, 
let me know if you find something 👌 

<img width="376" alt="image" src="https://user-images.githubusercontent.com/2688806/53687354-9e344c80-3d01-11e9-901b-f17c638a8d59.png">