### PR TITLE
Avoid lots of small append operations when grouping polygons by material

### DIFF
--- a/Sources/Mesh.swift
+++ b/Sources/Mesh.swift
@@ -43,11 +43,16 @@ public extension Mesh {
     /// Polygons grouped by material
     var polygonsByMaterial: [Polygon.Material: [Polygon]] {
         var polygonsByMaterial = [Polygon.Material: [Polygon]]()
-        for polygon in polygons {
-            var array = polygonsByMaterial[polygon.material] ?? []
-            array.append(polygon)
-            polygonsByMaterial[polygon.material] = array
+        
+        if (polygons.isEmpty) {
+            return polygonsByMaterial
         }
+                
+        let materials = Set(polygons.map { $0.material })
+        for material in materials {
+            polygonsByMaterial[material] = polygons.filter { $0.material == material }
+        }
+        
         return polygonsByMaterial
     }
 


### PR DESCRIPTION
I was finding the "polygonsByMaterial" part of converting to SCNGeometry incredibly slow for complex meshes - I think because of lots and lots of Array "append" operations. Benchmarking suggests that this method is significantly more efficient - I presume that `filter` does some clever allocation work to avoid having to constantly reallocate memory