### PR TITLE
Add some tolerance to bounds intersection

### DIFF
--- a/Sources/Bounds.swift
+++ b/Sources/Bounds.swift
@@ -110,9 +110,9 @@ public extension Bounds {
 
     func intersects(_ other: Bounds) -> Bool {
         return !(
-            other.max.x < min.x || other.min.x > max.x ||
-                other.max.y < min.y || other.min.y > max.y ||
-                other.max.z < min.z || other.min.z > max.z
+            other.max.x + epsilon < min.x || other.min.x > max.x + epsilon ||
+                other.max.y + epsilon < min.y || other.min.y > max.y + epsilon ||
+                other.max.z + epsilon < min.z || other.min.z > max.z + epsilon
         )
     }
 


### PR DESCRIPTION
So.... for me, this fixes the issue with union returning overlapping polygons: https://github.com/nicklockwood/Euclid/issues/19

... I haven't yet tested other cases to see if it introduces new issues, but it feels logically like the right thing to do.

Would value any opinions on whether it's likely to break other stuff!