### PR TITLE
Handle the loft case where the two edges are not parallel

### DIFF
--- a/Sources/Shapes.swift
+++ b/Sources/Shapes.swift
@@ -758,6 +758,21 @@ public extension Mesh {
                         vertices.remove(at: 2)
                     }
                 }
+                if vertices.count == 4 {
+                    // See if the vertices lie in a plane or not
+                    if Plane(points: vertices.map { $0.position }) == nil {
+                        let vertices2 = [vertices[0], vertices[2], vertices[3]]
+                        vertices.remove(at: 3)
+                        
+                        if !verticesAreDegenerate(vertices2) {
+                            polygons.append(Polygon(
+                                unchecked: invert ? vertices2.reversed() : vertices2,
+                                isConvex: true,
+                                material: material
+                            ))
+                        }
+                    }
+                }
                 if !verticesAreDegenerate(vertices) {
                     polygons.append(Polygon(
                         unchecked: invert ? vertices.reversed() : vertices,


### PR DESCRIPTION
I was having issues when trying to do a loft with two shapes where the corresponding edges weren't parallel, and so the resulting set of four points weren't in the same plane. This feels like it's probably the right way to handle that situation?