### PR TITLE
Add plane line intersection and direction utils

### DIFF
--- a/Sources/Plane.swift
+++ b/Sources/Plane.swift
@@ -125,6 +125,19 @@ public extension Plane {
         }
         return Line(origin: origin, direction: normal.cross(p.normal))
     }
+
+    /// Returns point intersection beteween plane and line
+    func intersection(with line: Line) -> Vector? {
+        // https://en.wikipedia.org/wiki/Line–plane_intersection#Algebraic_form
+        guard !directionsAreNormal(line.direction, normal) else {
+            return nil
+        }
+        let lineDotPlaneNormal = line.direction.dot(normal)
+        let planePoint = normal * w
+        let d = (planePoint - line.origin).dot(normal) / lineDotPlaneNormal
+        let intersection = line.origin + line.direction * d
+        return intersection
+    }
 }
 
 internal extension Plane {

--- a/Sources/Utilities.swift
+++ b/Sources/Utilities.swift
@@ -286,3 +286,27 @@ func lineSegmentsIntersect(
     }
     return true
 }
+
+func directionsAreParallel(_ d0: Vector, _ d1: Vector) -> Bool {
+    assert(d0.isNormalized)
+    assert(d1.isNormalized)
+    return abs(d0.dot(d1) - 1) <= epsilon
+}
+
+func directionsAreAntiparallel(_ d0: Vector, _ d1: Vector) -> Bool {
+    assert(d0.isNormalized)
+    assert(d1.isNormalized)
+    return abs(d0.dot(d1) + 1) <= epsilon
+}
+
+func directionsAreColinear(_ d0: Vector, _ d1: Vector) -> Bool {
+    assert(d0.isNormalized)
+    assert(d1.isNormalized)
+    return directionsAreParallel(d0, d1) || directionsAreAntiparallel(d0, d1)
+}
+
+func directionsAreNormal(_ d0: Vector, _ d1: Vector) -> Bool {
+    assert(d0.isNormalized)
+    assert(d1.isNormalized)
+    return abs(d0.dot(d1)) <= epsilon
+}

--- a/Tests/PlaneTests.swift
+++ b/Tests/PlaneTests.swift
@@ -65,4 +65,31 @@ class PlaneTests: XCTestCase {
         XCTAssert(plane1.containsPoint(intersection.origin + intersection.direction))
         XCTAssert(plane2.containsPoint(intersection.origin + intersection.direction))
     }
+
+    func testIntersectWithParallelLine() {
+        let line = Line(unchecked: Vector(0, 0, 0), direction: Vector(4, -5, 0).normalized())
+        let plane = Plane(unchecked: Vector(0, 0, 1), pointOnPlane: Vector(-3, 2, 0))
+        XCTAssertNil(plane.intersection(with: line))
+    }
+
+    func testIntersectWithNormalLine() {
+        let line = Line(unchecked: Vector(1, 5, 60), direction: Vector(0, 0, 1))
+        let plane = Plane(unchecked: Vector(0, 0, 1), pointOnPlane: Vector(-3, 2, 0))
+        let expected = Vector(1, 5, 0)
+        XCTAssertEqual(expected, plane.intersection(with: line)!)
+    }
+
+    func testIntersectionWithAxisLine() {
+        let line = Line(unchecked: Vector(0, 0, 0), direction: Vector(4, 3, 0).normalized())
+        let plane = Plane(unchecked: Vector(0, 1, 0), w: 3)
+        let expected = Vector(4, 3, 0)
+        XCTAssertEqual(expected, plane.intersection(with: line)!)
+    }
+
+    func testIntersectionWithSkewedLine() {
+        let line = Line(unchecked: Vector(8, 8, 10), direction: Vector(1, 1, 1).normalized())
+        let plane = Plane(unchecked: Vector(0, 0, 1), pointOnPlane: Vector(5, -7, 2))
+        let expected = Vector(0, 0, 2)
+        XCTAssertEqual(expected, plane.intersection(with: line)!)
+    }
 }

--- a/Tests/UtilityTests.swift
+++ b/Tests/UtilityTests.swift
@@ -112,4 +112,42 @@ class UtilityTests: XCTestCase {
             .point(0.18, 0.245),
         ])
     }
+
+    // MARK: directions
+
+    func testParallelDirections() {
+        let direction1 = Vector(-1, 1, 3).normalized()
+        let direction2 = Vector(-1, 1, 3).normalized()
+        XCTAssertTrue(directionsAreParallel(direction1, direction2))
+        XCTAssertFalse(directionsAreAntiparallel(direction1, direction2))
+        XCTAssertTrue(directionsAreColinear(direction1, direction2))
+        XCTAssertFalse(directionsAreNormal(direction1, direction2))
+    }
+
+    func testAntiparallelDirections() {
+        let direction1 = Vector(-1, 2, 3).normalized()
+        let direction2 = Vector(1, -2, -3).normalized()
+        XCTAssertFalse(directionsAreParallel(direction1, direction2))
+        XCTAssertTrue(directionsAreAntiparallel(direction1, direction2))
+        XCTAssertTrue(directionsAreColinear(direction1, direction2))
+        XCTAssertFalse(directionsAreNormal(direction1, direction2))
+    }
+
+    func testNormalDirections() {
+        let direction1 = Vector(1, 0, 0).normalized()
+        let direction2 = Vector(0, 1, 0).normalized()
+        XCTAssertFalse(directionsAreParallel(direction1, direction2))
+        XCTAssertFalse(directionsAreAntiparallel(direction1, direction2))
+        XCTAssertFalse(directionsAreColinear(direction1, direction2))
+        XCTAssertTrue(directionsAreNormal(direction1, direction2))
+    }
+
+    func testGeneralDirections() {
+        let direction1 = Vector(-1, 2, 3).normalized()
+        let direction2 = Vector(5, -9, 1).normalized()
+        XCTAssertFalse(directionsAreParallel(direction1, direction2))
+        XCTAssertFalse(directionsAreAntiparallel(direction1, direction2))
+        XCTAssertFalse(directionsAreColinear(direction1, direction2))
+        XCTAssertFalse(directionsAreNormal(direction1, direction2))
+    }
 }

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -210,9 +210,13 @@ extension PlaneTests {
     // to regenerate.
     static let __allTests__PlaneTests = [
         ("testConcavePolygonClockwiseWinding", testConcavePolygonClockwiseWinding),
+        ("testIntersectionWithAxisLine", testIntersectionWithAxisLine),
         ("testIntersectionWithParallelPlane", testIntersectionWithParallelPlane),
         ("testIntersectionWithPerpendicularPlane", testIntersectionWithPerpendicularPlane),
         ("testIntersectionWithRandomPlane", testIntersectionWithRandomPlane),
+        ("testIntersectionWithSkewedLine", testIntersectionWithSkewedLine),
+        ("testIntersectWithNormalLine", testIntersectWithNormalLine),
+        ("testIntersectWithParallelLine", testIntersectWithParallelLine),
     ]
 }
 
@@ -317,11 +321,15 @@ extension UtilityTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__UtilityTests = [
+        ("testAntiparallelDirections", testAntiparallelDirections),
         ("testColinearPointsDontPreventConvexness", testColinearPointsDontPreventConvexness),
         ("testConvexnessResultNotAffectedByTranslation", testConvexnessResultNotAffectedByTranslation),
         ("testDegenerateColinearVertices", testDegenerateColinearVertices),
         ("testDegenerateVerticesWithZeroLengthEdge", testDegenerateVerticesWithZeroLengthEdge),
+        ("testGeneralDirections", testGeneralDirections),
         ("testNonDegenerateColinearVertices", testNonDegenerateColinearVertices),
+        ("testNormalDirections", testNormalDirections),
+        ("testParallelDirections", testParallelDirections),
         ("testRemoveZeroAreaColinearPointRemoved", testRemoveZeroAreaColinearPointRemoved),
         ("testSanitizeInvalidClosedPath", testSanitizeInvalidClosedPath),
     ]


### PR DESCRIPTION
Porting over @jkalias work on line-plane intersection and few utilities around direction. See original branch. https://github.com/jkalias/Euclid/tree/line-plane

I found the utilities useful just want to bring it over following existing style so it can be merged quickly.