### PR TITLE
Fix incorrect Vertex normal value being encoded as texture coordinate

### DIFF
--- a/Sources/Vertex.swift
+++ b/Sources/Vertex.swift
@@ -63,7 +63,7 @@ extension Vertex: Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(position, forKey: .position)
         try container.encode(normal, forKey: .normal)
-        try texcoord == .zero ? () : container.encode(normal, forKey: .texcoord)
+        try texcoord == .zero ? () : container.encode(texcoord, forKey: .texcoord)
     }
 }
 


### PR DESCRIPTION
A simple fix where the texture coordinates of a `Vertex` are incorrectly being encoded using the normal instead.