### PR TITLE
updating markdown link to current CI build location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ When making user-facing changes, please update the README.md file if applicable.
 
 All significant code changes should be accompanied by a test.  
 
-Tests are run in [Travis CI](https://travis-ci.org/nicklockwood/Euclid) automatically on all pull requests, branches and tags. These are the same tests that run in Xcode at development time.
+Tests are run in [Travis CI](https://travis-ci.com/github/nicklockwood/Euclid) automatically on all pull requests, branches and tags. These are the same tests that run in Xcode at development time.
 
 ## Code of Conduct
 


### PR DESCRIPTION
I was reading through the contributions guidelines, and when I followed the link to the current build in CI, I noticed that it had migrated to travis-ci.com. This updates the link in the contribution guidelines to the build's updated location.