### PR TITLE
Line segment assertion test

### DIFF
--- a/Euclid.xcodeproj/project.pbxproj
+++ b/Euclid.xcodeproj/project.pbxproj
@@ -50,6 +50,9 @@
 		01F2382023BF4160005EC9DB /* LineSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F2381F23BF4160005EC9DB /* LineSegment.swift */; };
 		0A240137256A64FB00C1535C /* AngleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A240136256A64FB00C1535C /* AngleTests.swift */; };
 		0A24013F256A671600C1535C /* Angle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A24013E256A671600C1535C /* Angle.swift */; };
+		189007B626AD6A8200F1F7EF /* Frond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 189007B526AD6A8200F1F7EF /* Frond.swift */; };
+		18E6D30B26AD7CB7002ACB68 /* Chonk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E6D30A26AD7CB7002ACB68 /* Chonk.swift */; };
+		18E6D30D26AD7D1A002ACB68 /* Prop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18E6D30C26AD7D1A002ACB68 /* Prop.swift */; };
 		52A3852E238D6E5700BE8407 /* LineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A3852D238D6E5700BE8407 /* LineTests.swift */; };
 		52A663A123857D5300FACF9D /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A663A023857D5300FACF9D /* Line.swift */; };
 		52C844E223854CDF009C0A73 /* VectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C844E023854C87009C0A73 /* VectorTests.swift */; };
@@ -133,6 +136,9 @@
 		01F2381F23BF4160005EC9DB /* LineSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineSegment.swift; sourceTree = "<group>"; };
 		0A240136256A64FB00C1535C /* AngleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AngleTests.swift; sourceTree = "<group>"; };
 		0A24013E256A671600C1535C /* Angle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Angle.swift; sourceTree = "<group>"; };
+		189007B526AD6A8200F1F7EF /* Frond.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Frond.swift; sourceTree = "<group>"; };
+		18E6D30A26AD7CB7002ACB68 /* Chonk.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Chonk.swift; sourceTree = "<group>"; };
+		18E6D30C26AD7D1A002ACB68 /* Prop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prop.swift; sourceTree = "<group>"; };
 		52A3852D238D6E5700BE8407 /* LineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineTests.swift; sourceTree = "<group>"; };
 		52A663A023857D5300FACF9D /* Line.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
 		52C844E023854C87009C0A73 /* VectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorTests.swift; sourceTree = "<group>"; };
@@ -251,6 +257,8 @@
 		016FABEB21C078E400AF60DC /* Example */ = {
 			isa = PBXGroup;
 			children = (
+				18E6D30A26AD7CB7002ACB68 /* Chonk.swift */,
+				189007B526AD6A8200F1F7EF /* Frond.swift */,
 				016FABEC21C078E400AF60DC /* AppDelegate.swift */,
 				016FABF021C078E400AF60DC /* SceneViewController.swift */,
 				010D941826A784A400DB2414 /* Mesh.json */,
@@ -258,6 +266,7 @@
 				016FABF521C078E500AF60DC /* Assets.xcassets */,
 				016FABF721C078E500AF60DC /* LaunchScreen.storyboard */,
 				016FABFA21C078E500AF60DC /* Info.plist */,
+				18E6D30C26AD7D1A002ACB68 /* Prop.swift */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -518,7 +527,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				18E6D30D26AD7D1A002ACB68 /* Prop.swift in Sources */,
 				016FABF121C078E400AF60DC /* SceneViewController.swift in Sources */,
+				18E6D30B26AD7CB7002ACB68 /* Chonk.swift in Sources */,
+				189007B626AD6A8200F1F7EF /* Frond.swift in Sources */,
 				016FABED21C078E400AF60DC /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Chonk.swift
+++ b/Example/Chonk.swift
@@ -1,0 +1,98 @@
+//
+//  Chonk.swift
+//
+//  Created by Zack Brown on 16/06/2021.
+//
+
+import Euclid
+import Foundation
+
+struct Chonk: Prop {
+    
+    var peakCenter: Vector { (plane.normal * ((height / 2.0) + peak)) }
+    var baseCenter: Vector { (plane.normal * (base + (height / 2.0))) }
+    
+    let plane: Plane
+    
+    let peak: Double
+    let base: Double
+    let height: Double
+    
+    let peakRadius: Double
+    let baseRadius: Double
+    
+    let segments: Int
+    
+    func build(position: Vector) -> [Polygon] {
+        
+        var slices: [[Vector]] = []
+        
+        //
+        /// Create peak and base vertices
+        //
+        
+        let rotation = Angle(radians: (Double.pi * 2.0) / Double(segments))
+        
+        for slice in 0...1 {
+            
+            var layer: [Vector] = []
+            
+            let radius = slice == 0 ? baseRadius : peakRadius
+            
+            for segment in 0..<segments {
+                
+                let angle = rotation * Double(segment)
+                
+                let distance = (slice == 0 ? -1 : 1) * (height / 2.0)
+                
+                layer.append(plot(radians: angle.radians, radius: radius).project(onto: plane) + (plane.normal * distance))
+            }
+            
+            slices.append(layer)
+        }
+        
+        //
+        /// Create faces for peak, base and edge
+        //
+        
+        guard let upper = slices.last,
+              let lower = slices.first else { return [] }
+        
+        var polygons: [Polygon] = []
+        
+        for segment in 0..<segments {
+            
+            let v0 = position + upper[(segment + 1) % segments]
+            let v1 = position + upper[segment]
+            let v2 = position + lower[segment]
+            let v3 = position + lower[(segment + 1) % segments]
+            
+            //
+            /// Create edge face
+            //
+            
+            guard let lhs = self.polygon(vectors: [v0, v1, v2]),
+                  let rhs = self.polygon(vectors: [v0, v2, v3]) else { continue }
+            
+            polygons.append(contentsOf: [lhs, rhs])
+            
+            //
+            /// Create peak face
+            //
+            
+            guard let polygon = self.polygon(vectors: [v1, v0, position + peakCenter]) else { continue }
+            
+            polygons.append(polygon)
+            
+            //
+            /// Create base face
+            //
+            
+            guard let polygon = self.polygon(vectors: [v3, v2, position - baseCenter]) else { continue }
+            
+            polygons.append(polygon)
+        }
+        
+        return polygons
+    }
+}

--- a/Example/Frond.swift
+++ b/Example/Frond.swift
@@ -1,0 +1,167 @@
+//
+//  Frond.swift
+//
+//  Created by Zack Brown on 18/06/2021.
+//
+
+import Euclid
+import Foundation
+
+struct Frond: Prop {
+    
+    let plane: Plane
+    
+    let angle: Double
+    let radius: Double
+    let width: Double
+    let thickness: Double
+    let spread: Double
+    
+    let segments: Int
+
+    func build(position: Vector) -> [Polygon] {
+            
+        let step = Double(1.0 / Double(segments))
+        
+        let anchor = plot(radians: angle, radius: radius)
+        let control = position + anchor.project(onto: plane)
+        let end = control + (-plane.normal * radius)
+        let middle = curve(start: position, end: end, control: control, interpolator: 0.5)
+        let perpendicular = [position, middle, end].normal()
+        var length = ease(curve: .out, value: step) * width
+        
+        var polygons: [Euclid.Polygon] = []
+        
+        var sweep = (lhs: position + (-perpendicular * (length / 2.0)),
+                     curve: position,
+                     rhs: position + (perpendicular * (length / 2.0)))
+        
+        for segment in 1..<segments {
+
+            let interpolator = step * Double(segment)
+
+            let point = curve(start: position, end: end, control: control, interpolator: interpolator)
+
+            length = ease(curve: .out, value: interpolator) * width
+
+            let current = (lhs: (point + (-perpendicular * length)),
+                           curve: point,
+                           rhs: (point + (perpendicular * length)))
+            
+            let lhs = [sweep.curve, sweep.lhs, current.lhs, current.curve]
+            let rhs = [sweep.rhs, sweep.curve, current.curve, current.rhs]
+            
+            let cut0 = Double.random(in: 0...10) <= 1
+            let cut1 = Double.random(in: 0...10) <= 1
+            
+            polygons.append(contentsOf: face(vertices: lhs, side: .left, cut: cut0))
+            polygons.append(contentsOf: face(vertices: rhs, side: .right, cut: cut1))
+            
+            if segment == 1 {
+                
+                let n0 = lhs.normal()
+                let n1 = rhs.normal()
+                
+                let v0 = sweep.lhs - (n0 * thickness)
+                let v1 = sweep.rhs - (n1 * thickness)
+                let v2 = v0.lerp(v1, 0.5)
+                
+                guard let lf0 = polygon(vectors: [sweep.lhs, sweep.curve, v2]),
+                      let lf1 = polygon(vectors: [sweep.lhs, v2, v0]),
+                      let rf0 = polygon(vectors: [sweep.curve, sweep.rhs, v1]),
+                      let rf1 = polygon(vectors: [sweep.curve, v1, v2]) else { continue }
+                
+                polygons.append(contentsOf: [lf0, lf1, rf0, rf1])
+            }
+
+            sweep = current
+        }
+
+        let upperFace = [sweep.rhs, sweep.lhs, end]
+        let normal = upperFace.normal()
+        let lowerFace = [end, sweep.lhs, sweep.rhs].map{ $0 - (normal * thickness) }
+        let leftFace = [upperFace[2], upperFace[1], lowerFace[1], lowerFace[0]]
+        let rightFace = [upperFace[0], upperFace[2], lowerFace[0], lowerFace[2]]
+        
+        guard let upperPolygon = self.polygon(vectors: upperFace),
+              let lowerPolygon = self.polygon(vectors: lowerFace),
+              let lp0 = self.polygon(vectors: [leftFace[0], leftFace[1], leftFace[2]]),
+              let lp1 = self.polygon(vectors: [leftFace[0], leftFace[2], leftFace[3]]),
+              let rp0 = self.polygon(vectors: [rightFace[0], rightFace[1], rightFace[2]]),
+              let rp1 = self.polygon(vectors: [rightFace[0], rightFace[2], rightFace[3]]) else { return polygons }
+
+        polygons.append(contentsOf: [upperPolygon, lowerPolygon, lp0, lp1, rp0, rp1])
+        
+        return polygons
+    }
+}
+
+extension Frond {
+    
+    enum Side {
+        
+        case left
+        case right
+    }
+    
+    func face(vertices: [Vector], side: Side, cut: Bool) -> [Polygon] {
+        
+        let normal = vertices.normal()
+        
+        let lowerVertices = vertices.reversed().map { $0 - (normal * thickness) }
+        
+        let faces = (upper: (vertices: vertices, center: vertices.average()),
+                     lower: (vertices: lowerVertices, center: lowerVertices.average()))
+        
+        guard cut else {
+            
+            let edgeVertices = side == .left ? [faces.lower.vertices[2],
+                                                faces.lower.vertices[1],
+                                                faces.upper.vertices[2],
+                                                faces.upper.vertices[1]] :
+                                                [faces.upper.vertices[0],
+                                                 faces.upper.vertices[3],
+                                                 faces.lower.vertices[0],
+                                                 faces.lower.vertices[3]]
+            
+            guard let uf0 = polygon(vectors: [faces.upper.vertices[0], faces.upper.vertices[1], faces.upper.vertices[2]]),
+                  let uf1 = polygon(vectors: [faces.upper.vertices[0], faces.upper.vertices[2], faces.upper.vertices[3]]),
+                  let lf0 = polygon(vectors: [faces.lower.vertices[0], faces.lower.vertices[1], faces.lower.vertices[2]]),
+                  let lf1 = polygon(vectors: [faces.lower.vertices[0], faces.lower.vertices[2], faces.lower.vertices[3]]),
+                  let ef0 = polygon(vectors: [edgeVertices[0], edgeVertices[1], edgeVertices[2]]),
+                  let ef1 = polygon(vectors: [edgeVertices[0], edgeVertices[2], edgeVertices[3]]) else { return [] }
+            
+            return [uf0, uf1, lf0, lf1, ef0, ef1]
+        }
+        
+        let v0 = faces.upper.vertices.average()
+        let v1 = faces.upper.vertices[1].lerp(faces.upper.vertices[2], 0.5)
+        let v2 = faces.upper.vertices[0].lerp(faces.upper.vertices[3], 0.5)
+        
+        let v3 = v0 - (normal * thickness)
+        let v4 = v1 - (normal * thickness)
+        let v5 = v2 - (normal * thickness)
+        
+        let topFaces = face(vertices: [faces.upper.vertices[0], faces.upper.vertices[1], v1, v2], side: side, cut: false)
+        switch side {
+            
+        case .left:
+            
+            let bottomFaces = face(vertices: [v2, v0, faces.upper.vertices[2], faces.upper.vertices[3]], side: side, cut: false)
+            
+            guard let ef0 = polygon(vectors: [v0, v1, v4]),
+                  let ef1 = polygon(vectors: [v0, v4, v3]) else { return topFaces + bottomFaces }
+            
+            return topFaces + bottomFaces + [ef0, ef1]
+            
+        case .right:
+            
+            let bottomFaces = face(vertices: [v0, v1, faces.upper.vertices[2], faces.upper.vertices[3]], side: side, cut: false)
+            
+            guard let ef0 = polygon(vectors: [v2, v0, v3]),
+                  let ef1 = polygon(vectors: [v2, v3, v5]) else { return topFaces + bottomFaces }
+            
+            return topFaces + bottomFaces + [ef0, ef1]
+        }
+    }
+}

--- a/Example/Prop.swift
+++ b/Example/Prop.swift
@@ -1,0 +1,135 @@
+//
+//  Prop.swift
+//
+//  Created by Zack Brown on 25/07/2021.
+//
+
+import Euclid
+import Foundation
+
+public enum Curve {
+        
+    case `in`
+    case out
+    case inOut
+}
+
+protocol Prop {
+    
+    func build(position: Vector) -> [Polygon]
+}
+
+extension Prop {
+    
+    func polygon(vectors: [Vector]) -> Polygon? {
+            
+        let normal = vectors.normal()
+        
+        var vertices: [Vertex] = []
+        
+        for index in vectors.indices {
+            
+            vertices.append(Vertex(vectors[index], normal))
+        }
+        
+        return Polygon(vertices)
+    }
+    
+    func curve(start: Vector, end: Vector, control: Vector, interpolator: Double) -> Vector {
+            
+        let ab = start.lerp(control, interpolator)
+        let bc = control.lerp(end, interpolator)
+        
+        return ab.lerp(bc, interpolator)
+    }
+    
+    func plot(radians: Double, radius: Double) -> Vector {
+        
+        return Vector(sin(radians) * radius, 0, cos(radians) * radius)
+    }
+    
+    func lerp(start: Double, end: Double, interpolator: Double) -> Double {
+            
+        return start + (abs(end - start) * interpolator)
+    }
+}
+
+extension Prop {
+    
+    func ease(curve: Curve, value: Double) -> Double {
+        
+        switch curve {
+            
+        case .in: return value * value
+        case .out: return 1.0 - ease(curve: .in, value: 1.0 - value)
+        case .inOut: return lerp(start: ease(curve: .in, value: value), end: ease(curve: .out, value: value), interpolator: value)
+        }
+    }
+}
+
+extension Array where Element == Vector {
+    
+    func average() -> Vector {
+        
+        guard count > 0 else { return .zero }
+        
+        var x = 0.0
+        var y = 0.0
+        var z = 0.0
+        
+        for i in 0..<count {
+            
+            let vector = self[i]
+            
+            x += vector.x
+            y += vector.y
+            z += vector.z
+        }
+        
+        return Vector(x / Double(count), y / Double(count), z / Double(count))
+    }
+    
+    public func normal() -> Vector {
+        
+        switch count {
+            
+        case 0, 1: return Vector(0, 0, 1)
+            
+        case 2:
+            
+            let ab = self.last! - self.first!
+            
+            return ab.cross(Vector(0, 0, 1)).cross(ab)
+            
+        default:
+            
+            var v0 = self.first!
+            var v1: Vector?
+            
+            var ab = v0 - self.last!
+            
+            var magnitude = 0.0
+            
+            for vector in self {
+                
+                let bc = vector - v0
+                
+                let normal = ab.cross(bc)
+                
+                let squaredMagnitude = normal.lengthSquared
+                
+                if squaredMagnitude > magnitude {
+                    
+                    magnitude = squaredMagnitude
+                    
+                    v1 = normal / squaredMagnitude.squareRoot()
+                }
+                
+                v0 = vector
+                ab = bc
+            }
+            
+            return v1 ?? Vector(0, 0, 1)
+        }
+    }
+}

--- a/Example/SceneViewController.swift
+++ b/Example/SceneViewController.swift
@@ -27,21 +27,48 @@ class SceneViewController: UIViewController {
 
         // create some geometry using Euclid
         let start = CFAbsoluteTimeGetCurrent()
-
-        let url = Bundle.main.url(forResource: "Mesh", withExtension: "json")
-        let data = try! Data(contentsOf: url!)
-        let frond = try! JSONDecoder().decode(Mesh.self, from: data)
-
-        var mesh = Mesh([]) // start with empty mesh
-
-        // create foliage
-        var a = 0.0
-        for _ in 0 ..< 10 {
-            let r = Rotation(axis: Vector(0, 0, 1), angle: .degrees(a))!
-            a += 36
-            let frond = frond.translated(by: Vector(0, -1, 0)).rotated(by: r)
-
-            mesh = mesh.union(frond) // union into one big mesh
+        
+        let normal = Vector(0, 1, 0)
+        
+        guard let plane = Plane(normal: normal, pointOnPlane: .zero) else { fatalError("Error creating plane") }
+        
+        var position = Vector.zero
+        var mesh = Mesh([])
+        
+        let slices = 10
+        
+        let chonk = Chonk(plane: plane,
+                          peak: 0.05,
+                          base: 0.01,
+                          height: 0.125,
+                          peakRadius: 0.07,
+                          baseRadius: 0.05,
+                          segments: 7)
+        
+        for slice in 0..<slices {
+            
+            mesh = mesh.union(Mesh(chonk.build(position: position)))
+            
+            position += chonk.peakCenter
+        }
+        
+        let fronds = 10
+        
+        let rotation = Angle(radians: (Double.pi * 2.0) / Double(fronds))
+        
+        for leaf in 0..<fronds {
+            
+            let angle = (rotation.radians * Double(leaf))
+            
+            let frond = Frond(plane: plane,
+                              angle: angle,
+                              radius: 0.5,
+                              width: 0.1,
+                              thickness: 0.02,
+                              spread: 0.01,
+                              segments: 7)
+            
+            mesh = mesh.union(Mesh(frond.build(position: position)))
         }
 
         print("Time:", CFAbsoluteTimeGetCurrent() - start)


### PR DESCRIPTION
This PR should reproduce the `LineSegment` assertions [issue raised previously](https://github.com/nicklockwood/Euclid/issues/55).

Instead of using the encoded mesh I have lazily ported the appropriate code for generating the trunk and foliage as per its (approximate) usage. The assertions do not fire every time but are frequent enough you should be able to catch them in running the example app once or twice.