### PR TITLE
Vector semantics: line origin (1/7)

### DIFF
--- a/Sources/AdditiveArithmeticCartesianComponentsRepresentable.swift
+++ b/Sources/AdditiveArithmeticCartesianComponentsRepresentable.swift
@@ -26,21 +26,4 @@ public extension AdditiveArithmeticCartesianComponentsRepresentable {
             z: lhs.z - rhs.z
         )
     }
-
-    /// Linearly interpolate between two vectors
-    func lerp(_ a: Self, _ t: Double) -> Self {
-        Self(
-            x: x + (a.x - x) * t,
-            y: y + (a.y - y) * t,
-            z: z + (a.z - z) * t
-        )
-    }
-}
-
-internal extension AdditiveArithmeticCartesianComponentsRepresentable {
-    // Approximate equality
-    func isEqual(to other: Self, withPrecision p: Double = epsilon) -> Bool {
-        self == other ||
-            (abs(x - other.x) < p && abs(y - other.y) < p && abs(z - other.z) < p)
-    }
 }

--- a/Sources/CartesianComponentsRepresentable.swift
+++ b/Sources/CartesianComponentsRepresentable.swift
@@ -111,6 +111,25 @@ public extension CartesianComponentsRepresentable {
     }
 }
 
+internal extension CartesianComponentsRepresentable {
+    // Approximate equality
+    func isEqual(to other: Self, withPrecision p: Double = epsilon) -> Bool {
+        self == other ||
+            (abs(x - other.x) < p && abs(y - other.y) < p && abs(z - other.z) < p)
+    }
+}
+
+public extension CartesianComponentsRepresentable {
+    /// Linearly interpolate between two vectors
+    func lerp(_ a: Self, _ t: Double) -> Self {
+        Self(
+            x: x + (a.x - x) * t,
+            y: y + (a.y - y) * t,
+            z: z + (a.z - z) * t
+        )
+    }
+}
+
 public extension CartesianComponentsRepresentable {
     init(_ vector: Vector) {
         self.init(x: vector.x, y: vector.y, z: vector.z)

--- a/Sources/Direction.swift
+++ b/Sources/Direction.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Direction: AdditiveArithmeticCartesianComponentsRepresentable {
+public struct Direction: CartesianComponentsRepresentable {
     public let x: Double
     public let y: Double
     public let z: Double

--- a/Sources/Distance.swift
+++ b/Sources/Distance.swift
@@ -69,6 +69,10 @@ public extension Distance {
     func dot(_ direction: Direction) -> Double {
         self.direction.dot(direction) * norm
     }
+    
+    func dot(_ distance: Distance) -> Double {
+      dot(distance.direction) * distance.norm
+    }
 }
 
 public extension Distance {

--- a/Sources/Line.swift
+++ b/Sources/Line.swift
@@ -100,15 +100,15 @@ public extension Line {
 
     /// Distance of the line from another line
     func distance(from line: Line) -> Double {
-        guard let (p0, p1) = shortestLineBetween(
-            Vector(origin),
-            Vector(origin + 1 * direction),
-            Vector(line.origin),
-            Vector(line.origin + 1 * line.direction)
+        guard let (p0, p1) = shortestLineSegmentPositionsBetween(
+            origin,
+            origin + 1 * direction,
+            line.origin,
+            line.origin + 1 * line.direction
         ) else {
             return 0
         }
-        return (p1 - p0).length
+        return (p1 - p0).norm
     }
 
     /// Intersection point betwween plane and line (if any)

--- a/Sources/Line.swift
+++ b/Sources/Line.swift
@@ -35,7 +35,9 @@ public struct Line: Hashable {
 
     /// Creates a line from an origin and direction
     public init(origin: Position, direction: Direction) {
-        self.init(unchecked: Vector(origin), direction: direction)
+        let distance = Line.distanceAlongLineToFirstValidPlane(origin, direction)
+        self.origin = origin - distance * direction
+        self.direction = direction
     }
 }
 
@@ -83,7 +85,7 @@ extension Line: Codable {
 
 public extension Line {
     init(_ segment: LineSegment) {
-        self.init(unchecked: segment.start, direction: segment.direction)
+        self.init(origin: Position(segment.start), direction: segment.direction)
     }
 
     /// Check if point is on line
@@ -130,15 +132,8 @@ public extension Line {
     }
 }
 
-internal extension Line {
-    #warning("remove")
-    init(unchecked origin: Vector, direction: Direction) {
-        let distance = Line.distanceAlongLineToFirstValidPlane(origin, direction)
-        self.origin = Position(origin) - distance * direction
-        self.direction = direction
-    }
-    
-    private static func distanceAlongLineToFirstValidPlane(_ origin: Vector, _ direction: Direction) -> Double {
+private extension Line {
+    static func distanceAlongLineToFirstValidPlane(_ origin: Position, _ direction: Direction) -> Double {
         if direction.x != 0 {
             return origin.x / direction.x
         }

--- a/Sources/LineSegment.swift
+++ b/Sources/LineSegment.swift
@@ -89,11 +89,11 @@ public extension LineSegment {
 
     /// Check if point is on line segment
     func containsPoint(_ p: Vector) -> Bool {
-        let v = vectorFromPointToLine(p, start, direction)
-        guard v.length < epsilon else {
+        let v = distanceFromPointToLine(p, Line(unchecked: start, direction: direction))
+        guard v.norm < epsilon else {
             return false
         }
-        return lineSegmentsContainsPoint(start, end, p + v)
+        return lineSegmentsContainsPoint(start, end, p + Vector(v))
     }
 
     /// Intersection point between lines (if any)

--- a/Sources/LineSegment.swift
+++ b/Sources/LineSegment.swift
@@ -89,7 +89,7 @@ public extension LineSegment {
 
     /// Check if point is on line segment
     func containsPoint(_ p: Vector) -> Bool {
-        let v = distanceFromPointToLine(p, Line(unchecked: start, direction: direction))
+        let v = distanceFromPointToLine(p, Line(origin: Position(start), direction: direction))
         guard v.norm < epsilon else {
             return false
         }

--- a/Sources/Plane.swift
+++ b/Sources/Plane.swift
@@ -103,6 +103,10 @@ public extension Plane {
     func containsPoint(_ p: Vector) -> Bool {
         abs(p.distance(from: self)) < epsilon
     }
+    
+    func containsPoint(_ p: Position) -> Bool {
+        return containsPoint(Vector(p))
+    }
 
     /// Distance of the point from a plane
     /// A positive value is returned if the point lies in front of the plane
@@ -119,21 +123,21 @@ public extension Plane {
             // Planes do not intersect
             return nil
         }
-        return Line(origin: origin, direction: normal.cross(p.normal))
+        return Line(origin: Position(origin), direction: normal.cross(p.normal))
     }
 
     /// Returns point intersection between plane and line
     func intersection(with line: Line) -> Vector? {
         // https://en.wikipedia.org/wiki/Line–plane_intersection#Algebraic_form
-        let lineDotPlaneNormal = line.direction.dot(normal)
-        guard abs(lineDotPlaneNormal) > epsilon else {
+        let lineDirectionDotPlaneNormal = line.direction.dot(normal)
+        guard abs(lineDirectionDotPlaneNormal) > epsilon else {
             // Line and plane are parallel
             return nil
         }
-        let planePoint = w * normal
-        let d = (planePoint - Distance(line.origin)).dot(normal) / lineDotPlaneNormal
-        let intersection = line.origin + Vector(d * line.direction)
-        return intersection
+        let planePoint = Position.origin + w * normal
+        let d = (planePoint - line.origin).dot(normal) / lineDirectionDotPlaneNormal
+        let intersection = line.origin + d * line.direction
+        return Vector(intersection)
     }
 }
 

--- a/Sources/Position.swift
+++ b/Sources/Position.swift
@@ -25,6 +25,12 @@ public extension Position {
 }
 
 public extension Position {
+    var distance: Distance {
+        return Distance(x, y, z)
+    }
+}
+
+public extension Position {
     static func + (lhs: Position, rhs: Distance) -> Position {
         Position(
             x: lhs.x + rhs.x,

--- a/Sources/Shapes.swift
+++ b/Sources/Shapes.swift
@@ -840,11 +840,11 @@ public extension Mesh {
                     vertices.remove(at: 3)
                 } else {
                     if vertices[0].position == vertices[3].position {
-                        vertices[0].normal = vertices[0].normal + vertices[3].normal // auto-normalized
+                        vertices[0].normal = Direction.mean(vertices[0].normal, vertices[3].normal)
                         vertices.remove(at: 3)
                     }
                     if vertices[1].position == vertices[2].position {
-                        vertices[1].normal = vertices[1].normal + vertices[2].normal // auto-normalized
+                        vertices[1].normal = Direction.mean(vertices[1].normal, vertices[2].normal)
                         vertices.remove(at: 2)
                     }
                 }

--- a/Sources/Utilities.swift
+++ b/Sources/Utilities.swift
@@ -395,23 +395,24 @@ func cubicBezier(_ p0: Double, _ p1: Double, _ p2: Double, _ p3: Double, _ t: Do
 
 // Shortest line segment between two lines
 // http://paulbourke.net/geometry/pointlineplane/
+#warning("convert to Position")
 func shortestLineBetween(
-    _ p1: Vector,
-    _ p2: Vector,
-    _ p3: Vector,
-    _ p4: Vector
+    _ pa1: Vector,
+    _ pa2: Vector,
+    _ pb1: Vector,
+    _ pb2: Vector
 ) -> (Vector, Vector)? {
-    let p21 = p2 - p1
-    assert(p21.length > 0)
-    let p43 = p4 - p3
-    assert(p43.length > 0)
-    let p13 = p1 - p3
+    let pa = pa2 - pa1
+    assert(pa.length > 0)
+    let pb = pb2 - pb1
+    assert(pb.length > 0)
+    let p13 = pa1 - pb1
 
-    let d1343 = p13.dot(p43)
-    let d4321 = p43.dot(p21)
-    let d1321 = p13.dot(p21)
-    let d4343 = p43.dot(p43)
-    let d2121 = p21.dot(p21)
+    let d1343 = p13.dot(pb)
+    let d4321 = pb.dot(pa)
+    let d1321 = p13.dot(pa)
+    let d4343 = pb.dot(pb)
+    let d2121 = pa.dot(pa)
 
     let denominator = d2121 * d4343 - d4321 * d4321
     guard abs(denominator) > epsilon else {
@@ -423,17 +424,16 @@ func shortestLineBetween(
     let mua = numerator / denominator
     let mub = (d1343 + d4321 * mua) / d4343
 
-    return (p1 + mua * p21, p3 + mub * p43)
+    return (pa1 + mua * pa, pb1 + mub * pb)
 }
 
 // See "Vector formulation" at https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line
-func vectorFromPointToLine(
+func distanceFromPointToLine(
     _ point: Vector,
-    _ lineOrigin: Vector,
-    _ lineDirection: Direction
-) -> Vector {
-    let d = Distance(point - lineOrigin)
-    return Vector(d.dot(lineDirection) * lineDirection - d)
+    _ line: Line
+) -> Distance {
+    let d = Position(point) - line.origin
+    return d.dot(line.direction) * line.direction - d
 }
 
 func lineIntersection(
@@ -468,6 +468,7 @@ func lineSegmentsContainsPoint(
     _ end: Vector,
     _ point: Vector
 ) -> Bool {
-    assert(vectorFromPointToLine(point, start, Direction(end - start)).length < epsilon)
+    let line = Line(unchecked: start, direction: Direction(end - start))
+    assert(distanceFromPointToLine(point, line).norm < epsilon)
     return Bounds(min: min(start, end), max: max(start, end)).containsPoint(point)
 }

--- a/Sources/Utilities.swift
+++ b/Sources/Utilities.swift
@@ -395,24 +395,23 @@ func cubicBezier(_ p0: Double, _ p1: Double, _ p2: Double, _ p3: Double, _ t: Do
 
 // Shortest line segment between two lines
 // http://paulbourke.net/geometry/pointlineplane/
-#warning("convert to Position")
-func shortestLineBetween(
-    _ pa1: Vector,
-    _ pa2: Vector,
-    _ pb1: Vector,
-    _ pb2: Vector
-) -> (Vector, Vector)? {
-    let pa = pa2 - pa1
-    assert(pa.length > 0)
-    let pb = pb2 - pb1
-    assert(pb.length > 0)
-    let p13 = pa1 - pb1
+func shortestLineSegmentPositionsBetween(
+    _ p1: Position,
+    _ p2: Position,
+    _ p3: Position,
+    _ p4: Position
+) -> (Position, Position)? {
+    let p2p1 = p2 - p1
+    assert(p2p1.norm > 0)
+    let p4p3 = p4 - p3
+    assert(p4p3.norm > 0)
+    let p13 = p1 - p3
 
-    let d1343 = p13.dot(pb)
-    let d4321 = pb.dot(pa)
-    let d1321 = p13.dot(pa)
-    let d4343 = pb.dot(pb)
-    let d2121 = pa.dot(pa)
+    let d1343 = p13.dot(p4p3)
+    let d4321 = p4p3.dot(p2p1)
+    let d1321 = p13.dot(p2p1)
+    let d4343 = p4p3.dot(p4p3)
+    let d2121 = p2p1.dot(p2p1)
 
     let denominator = d2121 * d4343 - d4321 * d4321
     guard abs(denominator) > epsilon else {
@@ -424,7 +423,7 @@ func shortestLineBetween(
     let mua = numerator / denominator
     let mub = (d1343 + d4321 * mua) / d4343
 
-    return (pa1 + mua * pa, pb1 + mub * pb)
+    return (p1 + mua * p2p1, p3 + mub * p4p3)
 }
 
 // See "Vector formulation" at https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line
@@ -442,10 +441,10 @@ func lineIntersection(
     _ p2: Vector,
     _ p3: Vector
 ) -> Vector? {
-    guard let (p0, p1) = shortestLineBetween(p0, p1, p2, p3) else {
+    guard let (p0, p1) = shortestLineSegmentPositionsBetween(Position(p0), Position(p1), Position(p2), Position(p3)) else {
         return nil
     }
-    return p0.isEqual(to: p1) ? p0 : nil
+    return p0.isEqual(to: p1) ? Vector(p0) : nil
 }
 
 func lineSegmentsIntersection(

--- a/Sources/Utilities.swift
+++ b/Sources/Utilities.swift
@@ -468,7 +468,7 @@ func lineSegmentsContainsPoint(
     _ end: Vector,
     _ point: Vector
 ) -> Bool {
-    let line = Line(unchecked: start, direction: Direction(end - start))
+    let line = Line(origin: Position(start), direction: Direction(end - start))
     assert(distanceFromPointToLine(point, line).norm < epsilon)
     return Bounds(min: min(start, end), max: max(start, end)).containsPoint(point)
 }

--- a/Sources/Vector.swift
+++ b/Sources/Vector.swift
@@ -239,7 +239,7 @@ public extension Vector {
 
     /// The nearest point to this point on the specified line
     func project(onto line: Line) -> Vector {
-        self + vectorFromPointToLine(self, line.origin, line.direction)
+        self + Vector(distanceFromPointToLine(self, line))
     }
 }
 

--- a/Tests/CodingTests.swift
+++ b/Tests/CodingTests.swift
@@ -308,7 +308,7 @@ class CodingTests: XCTestCase {
             "origin": [0, 0, 1],
             "direction": [0, 1, 0]
         }
-        """), Line(origin: Vector(0, 0, 1), direction: .y))
+        """), Line(origin: Position(0, 0, 1), direction: .y))
     }
 
     func testDecodingKeyedZeroLengthLine() {
@@ -323,7 +323,7 @@ class CodingTests: XCTestCase {
     func testDecodingUnkeyedLine() {
         XCTAssertEqual(
             try decode("[0, 0, 1, 0, 1, 0]"),
-            Line(origin: Vector(0, 0, 1), direction: .y)
+            Line(origin: Position(0, 0, 1), direction: .y)
         )
     }
 
@@ -333,7 +333,7 @@ class CodingTests: XCTestCase {
 
     func testEncodingLine() {
         XCTAssertEqual(
-            try encode(Line(origin: Vector(0, 0, 1), direction: .y)),
+            try encode(Line(origin: Position(0, 0, 1), direction: .y)),
             "[0,0,1,0,1,0]"
         )
     }

--- a/Tests/DirectionTests.swift
+++ b/Tests/DirectionTests.swift
@@ -30,7 +30,7 @@ class DirectionTests: XCTestCase {
     func testNormedAdditionOnXYPlane() {
         let direction1 = Direction.x
         let direction2 = Direction.y
-        let direction = direction1 + direction2
+        let direction = Direction.mean(direction1, direction2)
         XCTAssertEqual(sqrt(2) / 2, direction.x, accuracy: epsilon)
         XCTAssertEqual(sqrt(2) / 2, direction.y, accuracy: epsilon)
         XCTAssertEqual(0, direction.z)
@@ -39,7 +39,7 @@ class DirectionTests: XCTestCase {
     func testNormedSubtractionOnXYPlane() {
         let direction1 = Direction.x
         let direction2 = Direction.y
-        let direction = direction1 - direction2
+        let direction = Direction.mean(direction1, -direction2)
         XCTAssertEqual(sqrt(2) / 2, direction.x, accuracy: epsilon)
         XCTAssertEqual(-sqrt(2) / 2, direction.y, accuracy: epsilon)
         XCTAssertEqual(0, direction.z)
@@ -48,7 +48,7 @@ class DirectionTests: XCTestCase {
     func testNormedAdditionOnXZPlane() {
         let direction1 = Direction.x
         let direction2 = Direction.z
-        let direction = direction1 + direction2
+        let direction = Direction.mean(direction1, direction2)
         XCTAssertEqual(sqrt(2) / 2, direction.x, accuracy: epsilon)
         XCTAssertEqual(0, direction.y)
         XCTAssertEqual(sqrt(2) / 2, direction.z, accuracy: epsilon)
@@ -57,7 +57,7 @@ class DirectionTests: XCTestCase {
     func testNormedSubtractionOnXZPlane() {
         let direction1 = Direction.x
         let direction2 = Direction.z
-        let direction = direction1 - direction2
+        let direction = Direction.mean(direction1, -direction2)
         XCTAssertEqual(sqrt(2) / 2, direction.x, accuracy: epsilon)
         XCTAssertEqual(0, direction.y)
         XCTAssertEqual(-sqrt(2) / 2, direction.z, accuracy: epsilon)
@@ -66,7 +66,7 @@ class DirectionTests: XCTestCase {
     func testNormedAdditionOnYZPlane() {
         let direction1 = Direction.y
         let direction2 = Direction.z
-        let direction = direction1 + direction2
+        let direction = Direction.mean(direction1, direction2)
         XCTAssertEqual(0, direction.x)
         XCTAssertEqual(sqrt(2) / 2, direction.y, accuracy: epsilon)
         XCTAssertEqual(sqrt(2) / 2, direction.z, accuracy: epsilon)
@@ -75,7 +75,7 @@ class DirectionTests: XCTestCase {
     func testNormedSubtractionOnYZPlane() {
         let direction1 = Direction.y
         let direction2 = Direction.z
-        let direction = direction1 - direction2
+        let direction = Direction.mean(direction1, -direction2)
         XCTAssertEqual(0, direction.x)
         XCTAssertEqual(sqrt(2) / 2, direction.y, accuracy: epsilon)
         XCTAssertEqual(-sqrt(2) / 2, direction.z, accuracy: epsilon)
@@ -84,7 +84,7 @@ class DirectionTests: XCTestCase {
     func testNormedAddition() {
         let direction1 = Direction(x: 1, y: 2, z: 3)
         let direction2 = Direction(x: 5, y: 6, z: 7)
-        let direction = direction1 + direction2
+        let direction = Direction.mean(direction1, direction2)
         XCTAssertEqual(0.37497702770252406, direction.x, accuracy: epsilon)
         XCTAssertEqual(0.55773354233061923, direction.y, accuracy: epsilon)
         XCTAssertEqual(0.74049005695871428, direction.z, accuracy: epsilon)

--- a/Tests/LineTests.swift
+++ b/Tests/LineTests.swift
@@ -13,13 +13,13 @@ class LineTests: XCTestCase {
     // MARK: Vector distance
 
     func testDistanceFromPointSimple() {
-        let l = Line(unchecked: Vector(0, 0, 0), direction: .x)
+        let l = Line(origin: .origin, direction: .x)
         let p = Vector(15, 2, 0)
         XCTAssertEqual(l.distance(from: p), 2)
     }
 
     func testDistanceFromPointHarder() {
-        let l = Line(unchecked: Vector(0, 0, 0), direction: .x)
+        let l = Line(origin: .origin, direction: .x)
         let p = Vector(15, 2, 3)
         XCTAssertEqual(l.distance(from: p), (2 * 2 + 3 * 3).squareRoot())
     }
@@ -27,31 +27,31 @@ class LineTests: XCTestCase {
     // MARK: Point projection
 
     func testProjectPointDown() {
-        let l = Line(unchecked: Vector(0, 0, 0), direction: .x)
+        let l = Line(origin: .origin, direction: .x)
         let p = Vector(2, -2, 0)
         XCTAssertEqual(p.project(onto: l), Vector(2, 0, 0))
     }
 
     func testProjectPointUp() {
-        let l = Line(unchecked: Vector(0, 0, 0), direction: .x)
+        let l = Line(origin: .origin, direction: .x)
         let p = Vector(3, 1, 0)
         XCTAssertEqual(p.project(onto: l), Vector(3, 0, 0))
     }
 
     func testProjectPointRight() {
-        let l = Line(unchecked: Vector(0, 0, 0), direction: .y)
+        let l = Line(origin: .origin, direction: .y)
         let p = Vector(-3, 1, 0)
         XCTAssertEqual(p.project(onto: l), Vector(0, 1, 0))
     }
 
     func testProjectPointLeft() {
-        let l = Line(unchecked: Vector(0, 0, 0), direction: .y)
+        let l = Line(origin: .origin, direction: .y)
         let p = Vector(3, -5, 0)
         XCTAssertEqual(p.project(onto: l), Vector(0, -5, 0))
     }
 
     func testProjectPointDiagonal() {
-        let l = Line(unchecked: Vector(0, 0, 0), direction: Direction(1, 1, 0))
+        let l = Line(origin: .origin, direction: Direction(1, 1, 0))
         let p = Vector(0, 2, 0)
         XCTAssert(p.project(onto: l).isEqual(to: Vector(1, 1, 0)))
     }
@@ -59,48 +59,48 @@ class LineTests: XCTestCase {
     // MARK: Line intersection
 
     func testLineIntersectionXY() {
-        let l1 = Line(unchecked: Vector(1, 0, 3), direction: .x)
-        let l2 = Line(unchecked: Vector(0, 1, 3), direction: -.y)
+        let l1 = Line(origin: Position(1, 0, 3), direction: .x)
+        let l2 = Line(origin: Position(0, 1, 3), direction: -.y)
 
         let intersection = l1.intersection(with: l2)
         XCTAssertEqual(intersection, Vector(0, 0, 3))
     }
 
     func testLineIntersectionXZ() {
-        let l1 = Line(unchecked: Vector(1, 3, 0), direction: .x)
-        let l2 = Line(unchecked: Vector(0, 3, 1), direction: -.z)
+        let l1 = Line(origin: Position(1, 3, 0), direction: .x)
+        let l2 = Line(origin: Position(0, 3, 1), direction: -.z)
 
         let intersection = l1.intersection(with: l2)
         XCTAssertEqual(intersection, Vector(0, 3, 0))
     }
 
     func testLineIntersectionYZ() {
-        let l1 = Line(unchecked: Vector(3, 1, 0), direction: .y)
-        let l2 = Line(unchecked: Vector(3, 0, 1), direction: -.z)
+        let l1 = Line(origin: Position(3, 1, 0), direction: .y)
+        let l2 = Line(origin: Position(3, 0, 1), direction: -.z)
 
         let intersection = l1.intersection(with: l2)
         XCTAssertEqual(intersection, Vector(3, 0, 0))
     }
 
     func testCoincidentLineIntersection() {
-        let l1 = Line(unchecked: Vector(1, 0), direction: .x)
+        let l1 = Line(origin: Position(x: 1, y: 0, z: 0), direction: .x)
         XCTAssertNil(l1.intersection(with: l1))
     }
 
     // MARK: Contains point
 
     func testContainsPoint() {
-        let line = Line(unchecked: Vector(-2, -1, 0), direction: Direction(2, 1, 0))
+        let line = Line(origin: Position(-2, -1, 0), direction: Direction(2, 1, 0))
         XCTAssert(line.containsPoint(Vector(-1, -0.5, 0)))
     }
 
     func testContainsPoint2() {
-        let line = Line(unchecked: Vector(-2, -1, 0), direction: Direction(2, 1, 0))
+        let line = Line(origin: Position(-2, -1, 0), direction: Direction(2, 1, 0))
         XCTAssert(line.containsPoint(Vector(-3, -1.5, 0)))
     }
 
     func testDoesNotContainPoint() {
-        let line = Line(unchecked: Vector(-2, -1, 0), direction: Direction(2, 1, 0))
+        let line = Line(origin: Position(-2, -1, 0), direction: Direction(2, 1, 0))
         XCTAssertFalse(line.containsPoint(Vector(-1, -0.6, 0)))
     }
 

--- a/Tests/LineTests.swift
+++ b/Tests/LineTests.swift
@@ -107,38 +107,38 @@ class LineTests: XCTestCase {
     // MARK: Equality
 
     func testEquivalentHorizontalLinesAreEqual() {
-        let l1 = Line(origin: Vector(1, -1, 0), direction: .x)
-        let l2 = Line(origin: Vector(3, -1, 0), direction: .x)
+        let l1 = Line(origin: Position(1, -1, 0), direction: .x)
+        let l2 = Line(origin: Position(3, -1, 0), direction: .x)
         XCTAssertEqual(l1, l2)
         XCTAssert(Set([l1]).contains(l2))
     }
 
     func testEquivalentVerticalLinesAreEqual() {
-        let l1 = Line(origin: Vector(2, 5, 0), direction: .y)
-        let l2 = Line(origin: Vector(2, -1, 0), direction: .y)
+        let l1 = Line(origin: Position(2, 5, 0), direction: .y)
+        let l2 = Line(origin: Position(2, -1, 0), direction: .y)
         XCTAssertEqual(l1, l2)
         XCTAssert(Set([l1]).contains(l2))
     }
 
     func testEquivalentZLinesAreEqual() {
-        let l1 = Line(origin: Vector(2, 5, -2), direction: -.z)
-        let l2 = Line(origin: Vector(2, 5, 7), direction: -.z)
+        let l1 = Line(origin: Position(2, 5, -2), direction: -.z)
+        let l2 = Line(origin: Position(2, 5, 7), direction: -.z)
         XCTAssertEqual(l1, l2)
         XCTAssert(Set([l1]).contains(l2))
     }
 
     func testEquivalentXYLinesAreEqual() {
         let direction = Direction(1, 2, 0)
-        let l1 = Line(origin: Vector(0, 0, -1), direction: direction)
-        let l2 = Line(origin: Vector(1, 2, -1), direction: direction)
+        let l1 = Line(origin: Position(0, 0, -1), direction: direction)
+        let l2 = Line(origin: Position(1, 2, -1), direction: direction)
         XCTAssertEqual(l1, l2)
         XCTAssert(Set([l1]).contains(l2))
     }
 
     func testEquivalentYZLinesAreEqual() {
         let direction = Direction(0, -1, 2)
-        let l1 = Line(origin: Vector(0, 0, 0), direction: direction)
-        let l2 = Line(origin: Vector(0, -1, 2), direction: direction)
+        let l1 = Line(origin: Position(0, 0, 0), direction: direction)
+        let l2 = Line(origin: Position(0, -1, 2), direction: direction)
         XCTAssertEqual(l1, l2)
         XCTAssert(Set([l1]).contains(l2))
     }

--- a/Tests/PlaneTests.swift
+++ b/Tests/PlaneTests.swift
@@ -126,27 +126,27 @@ class PlaneTests: XCTestCase {
     }
 
     func testIntersectWithParallelLine() {
-        let line = Line(unchecked: Vector(0, 0, 0), direction: Direction(4, -5, 0))
+        let line = Line(origin: .origin, direction: Direction(4, -5, 0))
         let plane = Plane(unchecked: .z, pointOnPlane: Vector(-3, 2, 0))
         XCTAssertNil(plane.intersection(with: line))
     }
 
     func testIntersectWithNormalLine() {
-        let line = Line(unchecked: Vector(1, 5, 60), direction: .z)
+        let line = Line(origin: Position(1, 5, 60), direction: .z)
         let plane = Plane(unchecked: .z, pointOnPlane: Vector(-3, 2, 0))
         let expected = Vector(1, 5, 0)
         XCTAssertEqual(expected, plane.intersection(with: line))
     }
 
     func testIntersectionWithAxisLine() {
-        let line = Line(unchecked: Vector(0, 0, 0), direction: Direction(4, 3, 0))
+        let line = Line(origin: .origin, direction: Direction(4, 3, 0))
         let plane = Plane(normal: .y, w: 3)
         let expected = Vector(4, 3, 0)
         XCTAssertEqual(expected, plane.intersection(with: line))
     }
 
     func testIntersectionWithSkewedLine() {
-        let line = Line(unchecked: Vector(8, 8, 10), direction: Direction(1, 1, 1))
+        let line = Line(origin: Position(8, 8, 10), direction: Direction(1, 1, 1))
         let plane = Plane(unchecked: .z, pointOnPlane: Vector(5, -7, 2))
         let expected = Vector(0, 0, 2)
         XCTAssertEqual(expected, plane.intersection(with: line))

--- a/Tests/PlaneTests.swift
+++ b/Tests/PlaneTests.swift
@@ -102,8 +102,8 @@ class PlaneTests: XCTestCase {
         XCTAssert(plane1.containsPoint(intersection.origin))
         XCTAssert(plane2.containsPoint(intersection.origin))
 
-        XCTAssert(plane1.containsPoint(intersection.origin + Vector(intersection.direction)))
-        XCTAssert(plane2.containsPoint(intersection.origin + Vector(intersection.direction)))
+        XCTAssert(plane1.containsPoint(intersection.origin + 1 * intersection.direction))
+        XCTAssert(plane2.containsPoint(intersection.origin + 1 * intersection.direction))
     }
 
     func testIntersectionWithRandomPlane() {
@@ -115,14 +115,14 @@ class PlaneTests: XCTestCase {
             return
         }
 
-        XCTAssert(abs(Distance(intersection.origin).dot(plane1.normal) - plane1.w) < epsilon)
-        XCTAssert(abs(Distance(intersection.origin).dot(plane2.normal) - plane2.w) < epsilon)
+        XCTAssert(abs(intersection.origin.distance.dot(plane1.normal) - plane1.w) < epsilon)
+        XCTAssert(abs(intersection.origin.distance.dot(plane2.normal) - plane2.w) < epsilon)
 
         XCTAssert(plane1.containsPoint(intersection.origin))
         XCTAssert(plane2.containsPoint(intersection.origin))
 
-        XCTAssert(plane1.containsPoint(intersection.origin + Vector(intersection.direction)))
-        XCTAssert(plane2.containsPoint(intersection.origin + Vector(intersection.direction)))
+        XCTAssert(plane1.containsPoint(intersection.origin + 1 * intersection.direction))
+        XCTAssert(plane2.containsPoint(intersection.origin + 1 * intersection.direction))
     }
 
     func testIntersectWithParallelLine() {

--- a/Tests/PlaneTests.swift
+++ b/Tests/PlaneTests.swift
@@ -89,6 +89,13 @@ class PlaneTests: XCTestCase {
 
         XCTAssertNil(plane1.intersection(with: plane2))
     }
+    
+    func testIntersectionWithParallelPlaneInvertedNormal() {
+        let plane1 = Plane(unchecked: .y, pointOnPlane: Vector(0, 0, 0))
+        let plane2 = Plane(unchecked: -.y, pointOnPlane: Vector(0, 1, 0))
+
+        XCTAssertNil(plane1.intersection(with: plane2))
+    }
 
     func testIntersectionWithPerpendicularPlane() {
         let plane1 = Plane(unchecked: .y, pointOnPlane: Vector(0, 0, 0))
@@ -108,6 +115,44 @@ class PlaneTests: XCTestCase {
 
     func testIntersectionWithRandomPlane() {
         let plane1 = Plane(normal: Direction(1.2, 0.4, 5.7), w: 6)
+        let plane2 = Plane(normal: Direction(0.5, 0.7, 0.1), w: 8)
+
+        guard let intersection = plane1.intersection(with: plane2) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssert(abs(intersection.origin.distance.dot(plane1.normal) - plane1.w) < epsilon)
+        XCTAssert(abs(intersection.origin.distance.dot(plane2.normal) - plane2.w) < epsilon)
+
+        XCTAssert(plane1.containsPoint(intersection.origin))
+        XCTAssert(plane2.containsPoint(intersection.origin))
+
+        XCTAssert(plane1.containsPoint(intersection.origin + 1 * intersection.direction))
+        XCTAssert(plane2.containsPoint(intersection.origin + 1 * intersection.direction))
+    }
+    
+    func testIntersectionWithRandomPlaneInvertedNormal() {
+        let plane1 = Plane(normal: -Direction(1.2, 0.4, 5.7), w: 6)
+        let plane2 = Plane(normal: Direction(0.5, 0.7, 0.1), w: 8)
+
+        guard let intersection = plane1.intersection(with: plane2) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssert(abs(intersection.origin.distance.dot(plane1.normal) - plane1.w) < epsilon)
+        XCTAssert(abs(intersection.origin.distance.dot(plane2.normal) - plane2.w) < epsilon)
+
+        XCTAssert(plane1.containsPoint(intersection.origin))
+        XCTAssert(plane2.containsPoint(intersection.origin))
+
+        XCTAssert(plane1.containsPoint(intersection.origin + 1 * intersection.direction))
+        XCTAssert(plane2.containsPoint(intersection.origin + 1 * intersection.direction))
+    }
+    
+    func testIntersectionWithRandomPlaneInvertedNormalAndDistance() {
+        let plane1 = Plane(normal: -Direction(1.2, 0.4, 5.7), w: -6)
         let plane2 = Plane(normal: Direction(0.5, 0.7, 0.1), w: 8)
 
         guard let intersection = plane1.intersection(with: plane2) else {

--- a/Tests/UtilityTests.swift
+++ b/Tests/UtilityTests.swift
@@ -117,7 +117,7 @@ class UtilityTests: XCTestCase {
     func testVectorFromPointToLine() {
         let result = distanceFromPointToLine(
             Vector(2, 0),
-            Line(unchecked: Vector(-1, -1), direction: .x)
+            Line(origin: Position(x: -1, y: -1, z: 0), direction: .x)
         )
         XCTAssertEqual(result, Distance(0, -1, 0))
     }

--- a/Tests/UtilityTests.swift
+++ b/Tests/UtilityTests.swift
@@ -115,12 +115,11 @@ class UtilityTests: XCTestCase {
     // MARK: lines
 
     func testVectorFromPointToLine() {
-        let result = vectorFromPointToLine(
+        let result = distanceFromPointToLine(
             Vector(2, 0),
-            Vector(-1, -1),
-            .x
+            Line(unchecked: Vector(-1, -1), direction: .x)
         )
-        XCTAssertEqual(result, Vector(0, -1, 0))
+        XCTAssertEqual(result, Distance(0, -1, 0))
     }
 
     // MARK: faceNormalForPolygonPoints


### PR DESCRIPTION
Overview of remaining refactoring steps from #37:

`line.origin` -> `Position` **[this PR]**
`lineSegment.start/end` -> `Position` _[pending]_
`pathPoint.position` -> `Position` _[pending]_
`transform.offset` -> `Distance` _[pending]_
`transform.scale` -> `Distance` _[pending]_
`vertex.position` -> `Position` _[pending]_
`Plane(normal: Direction, pointOnPlane: Vector)` -> `pointOnPlane` should be `Position` _[pending]_