### PR TITLE
Vector semantics: line segment position (2/7)

### DIFF
--- a/Sources/CartesianComponentsRepresentable.swift
+++ b/Sources/CartesianComponentsRepresentable.swift
@@ -143,3 +143,15 @@ public extension CartesianComponentsRepresentable {
         )
     }
 }
+
+public extension CartesianComponentsRepresentable {
+    /// Returns a new instance representing the min of the components of the passed instances
+    static func min(_ lhs: Self, _ rhs: Self) -> Self {
+        Self(Swift.min(lhs.x, rhs.x), Swift.min(lhs.y, rhs.y), Swift.min(lhs.z, rhs.z))
+    }
+
+    /// Returns a new instance representing the max of the components of the passed instances
+    static func max(_ lhs: Self, _ rhs: Self) -> Self {
+        Self(Swift.max(lhs.x, rhs.x), Swift.max(lhs.y, rhs.y), Swift.max(lhs.z, rhs.z))
+    }
+}

--- a/Sources/Distance.swift
+++ b/Sources/Distance.swift
@@ -60,9 +60,9 @@ public extension Distance {
 
 public extension Distance {
     func cross(_ other: Distance) -> Distance {
-        return other.norm * cross(other.direction)
+        other.norm * cross(other.direction)
     }
-    
+
     func cross(_ other: Direction) -> Distance {
         let angle = direction.angle(with: other)
         let newNorm = norm * sin(angle)

--- a/Sources/Distance.swift
+++ b/Sources/Distance.swift
@@ -60,9 +60,13 @@ public extension Distance {
 
 public extension Distance {
     func cross(_ other: Distance) -> Distance {
-        let angle = direction.angle(with: other.direction)
-        let newNorm = norm * other.norm * sin(angle)
-        let normalDirection = direction.cross(other.direction)
+        return other.norm * cross(other.direction)
+    }
+    
+    func cross(_ other: Direction) -> Distance {
+        let angle = direction.angle(with: other)
+        let newNorm = norm * sin(angle)
+        let normalDirection = direction.cross(other)
         return newNorm * normalDirection
     }
 

--- a/Sources/Plane.swift
+++ b/Sources/Plane.swift
@@ -100,12 +100,8 @@ public extension Plane {
     }
 
     /// Checks if point is on plane
-    func containsPoint(_ p: Vector) -> Bool {
-        abs(p.distance(from: self)) < epsilon
-    }
-
     func containsPoint(_ p: Position) -> Bool {
-        containsPoint(Vector(p))
+        abs(p.distance(from: self)) < epsilon
     }
 
     /// Distance of the point from a plane
@@ -178,7 +174,7 @@ internal extension Plane {
         }
         self.init(unchecked: points, convex: convex)
         // Check all points lie on this plane
-        if points.contains(where: { !containsPoint($0) }) {
+        if points.contains(where: { !containsPoint(Position($0)) }) {
             return nil
         }
     }

--- a/Sources/Plane.swift
+++ b/Sources/Plane.swift
@@ -100,6 +100,11 @@ public extension Plane {
     }
 
     /// Checks if point is on plane
+    func containsPoint(_ p: Vector) -> Bool {
+        containsPoint(Position(p))
+    }
+
+    /// Checks if point is on plane
     func containsPoint(_ p: Position) -> Bool {
         abs(p.distance(from: self)) < epsilon
     }

--- a/Sources/Polygon.swift
+++ b/Sources/Polygon.swift
@@ -177,7 +177,7 @@ public extension Polygon {
 
     /// Test if point lies inside the polygon
     func containsPoint(_ p: Vector) -> Bool {
-        guard plane.containsPoint(p) else {
+        guard plane.containsPoint(Position(p)) else {
             return false
         }
         // https://stackoverflow.com/questions/217578/how-can-i-determine-whether-a-2d-point-is-within-a-polygon#218081

--- a/Sources/Position.swift
+++ b/Sources/Position.swift
@@ -55,3 +55,12 @@ public extension Position {
         )
     }
 }
+
+public extension Position {
+    /// Distance of the point from a plane
+    /// A positive value is returned if the point lies in front of the plane
+    /// A negative value is returned if the point lies behind the plane
+    func distance(from plane: Plane) -> Double {
+        distance.dot(plane.normal) - plane.w
+    }
+}

--- a/Sources/Rotation.swift
+++ b/Sources/Rotation.swift
@@ -232,16 +232,16 @@ public extension Rotation {
         .atan2(y: m21, x: m11)
     }
 
-    var right: Vector {
-        Vector(m11, m12, m13)
+    var right: Direction {
+        Direction(m11, m12, m13)
     }
 
-    var up: Vector {
-        Vector(m21, m22, m23)
+    var up: Direction {
+        Direction(m21, m22, m23)
     }
 
-    var forward: Vector {
-        Vector(m31, m32, m33)
+    var forward: Direction {
+        Direction(m31, m32, m33)
     }
 
     static prefix func - (rhs: Rotation) -> Rotation {

--- a/Sources/Utilities.swift
+++ b/Sources/Utilities.swift
@@ -349,7 +349,7 @@ func pointsAreCoplanar(_ points: [Vector]) -> Bool {
         return false
     }
     let plane = Plane(unchecked: Direction(normal), pointOnPlane: b)
-    for p in points[3...] where !plane.containsPoint(p) {
+    for p in points[3...] where !plane.containsPoint(Position(p)) {
         return false
     }
     return true

--- a/Sources/Utilities.swift
+++ b/Sources/Utilities.swift
@@ -286,19 +286,19 @@ func pointsAreSelfIntersecting(_ points: [Vector]) -> Bool {
 // Points are not required to form a convex polygon
 func faceNormalForPolygonPoints(_ points: [Vector], convex: Bool?) -> Direction {
     let count = points.count
-    let unitZ = Vector(0, 0, 1)
+    let unitZ = Direction.z
     switch count {
     case 0, 1:
         return .z
     case 2:
-        let ab = points[1] - points[0]
+        let ab = Distance(points[1] - points[0])
         let normal = ab.cross(unitZ).cross(ab)
-        let length = normal.length
+        let length = normal.norm
         guard length > 0 else {
             // Points lie along z axis
             return .x
         }
-        return Direction(normal / length)
+        return (normal / length).direction
     default:
         func faceNormalForConvexPoints(_ points: [Vector]) -> Direction {
             var b = points[0]

--- a/Sources/Vector.swift
+++ b/Sources/Vector.swift
@@ -218,17 +218,10 @@ public extension Vector {
         let complementeryAngle = Direction(self).dot(plane.normal)
         return Angle.asin(complementeryAngle)
     }
-
-    /// Distance of the point from a plane
-    /// A positive value is returned if the point lies in front of the plane
-    /// A negative value is returned if the point lies behind the plane
-    func distance(from plane: Plane) -> Double {
-        Distance(self).dot(plane.normal) - plane.w
-    }
-
+    
     /// The nearest point to this point on the specified plane
     func project(onto plane: Plane) -> Vector {
-        let position = Position(self) - distance(from: plane) * plane.normal
+        let position = Position(self) - Position(self).distance(from: plane) * plane.normal
         return Vector(position)
     }
 
@@ -251,7 +244,7 @@ internal extension Vector {
     }
 
     func compare(with plane: Plane) -> PlaneComparison {
-        let t = distance(from: plane)
+        let t = Position(self).distance(from: plane)
         return (t < -epsilon) ? .back : (t > epsilon) ? .front : .coplanar
     }
 

--- a/Sources/Vector.swift
+++ b/Sources/Vector.swift
@@ -218,7 +218,7 @@ public extension Vector {
         let complementeryAngle = Direction(self).dot(plane.normal)
         return Angle.asin(complementeryAngle)
     }
-    
+
     /// The nearest point to this point on the specified plane
     func project(onto plane: Plane) -> Vector {
         let position = Position(self) - Position(self).distance(from: plane) * plane.normal

--- a/Tests/PositionTests.swift
+++ b/Tests/PositionTests.swift
@@ -48,7 +48,7 @@ class PositionTests: XCTestCase {
         let rotated = position.rotated(around: .z, by: Angle(degrees: 150))
         XCTAssertEqual(Position(x: -sqrt(3), y: 1, z: 1), rotated)
     }
-    
+
     // MARK: Distance from plane
 
     func testDistanceInFrontOfPlane() {

--- a/Tests/PositionTests.swift
+++ b/Tests/PositionTests.swift
@@ -48,4 +48,18 @@ class PositionTests: XCTestCase {
         let rotated = position.rotated(around: .z, by: Angle(degrees: 150))
         XCTAssertEqual(Position(x: -sqrt(3), y: 1, z: 1), rotated)
     }
+    
+    // MARK: Distance from plane
+
+    func testDistanceInFrontOfPlane() {
+        let position = Position(2, 1, -2)
+        let plane = Plane(unchecked: .x, pointOnPlane: Vector.zero)
+        XCTAssertEqual(position.distance(from: plane), 2)
+    }
+
+    func testDistanceBehindPlane() {
+        let position = Position(-1.5, 2, 7)
+        let plane = Plane(unchecked: .x, pointOnPlane: Vector.zero)
+        XCTAssertEqual(position.distance(from: plane), -1.5)
+    }
 }

--- a/Tests/TransformTests.swift
+++ b/Tests/TransformTests.swift
@@ -70,10 +70,9 @@ class TransformTests: XCTestCase {
 
     func testRotationIdentityAxis() {
         let r = Rotation.identity
-
-        XCTAssertEqual(r.right, Vector(1, 0, 0))
-        XCTAssertEqual(r.up, Vector(0, 1, 0))
-        XCTAssertEqual(r.forward, Vector(0, 0, 1))
+        XCTAssertEqual(r.right, .x)
+        XCTAssertEqual(r.up, .y)
+        XCTAssertEqual(r.forward, .z)
     }
 
     // MARK: Transform multiplication

--- a/Tests/VectorTests.swift
+++ b/Tests/VectorTests.swift
@@ -44,18 +44,4 @@ class VectorTests: XCTestCase {
         let plane = Plane(unchecked: .x, pointOnPlane: Vector.zero)
         XCTAssertEqual(direction.angle(with: plane), .halfPi)
     }
-
-    // MARK: Distance from plane
-
-    func testDistanceInFrontOfPlane() {
-        let position = Vector(2, 1, -2)
-        let plane = Plane(unchecked: .x, pointOnPlane: Vector.zero)
-        XCTAssertEqual(position.distance(from: plane), 2)
-    }
-
-    func testDistanceBehindPlane() {
-        let position = Vector(-1.5, 2, 7)
-        let plane = Plane(unchecked: .x, pointOnPlane: Vector.zero)
-        XCTAssertEqual(position.distance(from: plane), -1.5)
-    }
 }


### PR DESCRIPTION
Overview of remaining refactoring steps from #37:

`line.origin` -> `Position` _[done]_
`lineSegment.start/end` -> `Position` **[this PR]**
`pathPoint.position` -> `Position` _[pending]_
`transform.offset` -> `Distance` _[pending]_
`transform.scale` -> `Distance` _[pending]_
`vertex.position` -> `Position` _[pending]_
`Plane(normal: Direction, pointOnPlane: Vector)` -> `pointOnPlane` should be `Position` _[pending]_