### PR TITLE
Vector semantics: path point (3/7)

### DIFF
--- a/Sources/Bounds.swift
+++ b/Sources/Bounds.swift
@@ -31,9 +31,9 @@
 
 /// An axially-aligned bounding box
 public struct Bounds: Hashable {
-    public let min, max: Vector
+    public let min, max: Position
 
-    public init(min: Vector, max: Vector) {
+    public init(min: Position, max: Position) {
         self.min = min
         self.max = max
     }
@@ -45,14 +45,14 @@ extension Bounds: Codable {
     }
 
     public init(from decoder: Decoder) throws {
-        let min, max: Vector
+        let min, max: Position
         if var container = try? decoder.unkeyedContainer() {
-            min = try Vector(from: &container)
-            max = try Vector(from: &container)
+            min = try Position(from: &container)
+            max = try Position(from: &container)
         } else {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            min = try container.decode(Vector.self, forKey: .min)
-            max = try container.decode(Vector.self, forKey: .max)
+            min = try container.decode(Position.self, forKey: .min)
+            max = try container.decode(Position.self, forKey: .max)
         }
         self.init(min: min, max: max)
     }
@@ -64,27 +64,30 @@ extension Bounds: Codable {
     }
 }
 
+private let positiveInfinity = Position(.infinity, .infinity, .infinity)
+private let negativeInfinity = Position(-.infinity, -.infinity, -.infinity)
+
 public extension Bounds {
     static let empty = Bounds()
 
-    init(points: [Vector] = []) {
-        var min = Vector(.infinity, .infinity, .infinity)
-        var max = Vector(-.infinity, -.infinity, -.infinity)
+    init(points: [Position] = []) {
+        var min = positiveInfinity
+        var max = negativeInfinity
         for p in points {
-            min = Euclid.min(min, p)
-            max = Euclid.max(max, p)
+            min = Position.min(min, p)
+            max = Position.max(max, p)
         }
         self.min = min
         self.max = max
     }
 
     init(polygons: [Polygon]) {
-        var min = Vector(.infinity, .infinity, .infinity)
-        var max = Vector(-.infinity, -.infinity, -.infinity)
+        var min = positiveInfinity
+        var max = negativeInfinity
         for p in polygons {
             for v in p.vertices {
-                min = Euclid.min(min, v.position)
-                max = Euclid.max(max, v.position)
+                min = Position.min(min, Position(v.position))
+                max = Position.max(max, Position(v.position))
             }
         }
         self.min = min
@@ -92,11 +95,11 @@ public extension Bounds {
     }
 
     init(bounds: [Bounds]) {
-        var min = Vector(.infinity, .infinity, .infinity)
-        var max = Vector(-.infinity, -.infinity, -.infinity)
+        var min = positiveInfinity
+        var max = negativeInfinity
         for b in bounds {
-            min = Euclid.min(min, b.min)
-            max = Euclid.max(max, b.max)
+            min = Position.min(min, b.min)
+            max = Position.max(max, b.max)
         }
         self.min = min
         self.max = max
@@ -107,23 +110,23 @@ public extension Bounds {
     }
 
     var size: Vector {
-        hasNegativeVolume ? .zero : max - min
+        hasNegativeVolume ? .zero : Vector(max - min)
     }
 
     var center: Vector {
-        hasNegativeVolume ? .zero : min + size / 2
+        hasNegativeVolume ? .zero : Vector(min) + size / 2
     }
 
-    var corners: [Vector] {
+    var corners: [Position] {
         [
             min,
-            Vector(min.x, max.y, min.z),
-            Vector(max.x, max.y, min.z),
-            Vector(max.x, min.y, min.z),
-            Vector(min.x, min.y, max.z),
-            Vector(min.x, max.y, max.z),
+            Position(min.x, max.y, min.z),
+            Position(max.x, max.y, min.z),
+            Position(max.x, min.y, min.z),
+            Position(min.x, min.y, max.z),
+            Position(min.x, max.y, max.z),
             max,
-            Vector(max.x, min.y, max.z),
+            Position(max.x, min.y, max.z),
         ]
     }
 
@@ -134,8 +137,8 @@ public extension Bounds {
             return self
         }
         return Bounds(
-            min: Euclid.min(min, other.min),
-            max: Euclid.max(max, other.max)
+            min: Position.min(min, other.min),
+            max: Position.max(max, other.max)
         )
     }
 
@@ -145,8 +148,8 @@ public extension Bounds {
 
     func intersection(_ other: Bounds) -> Bounds {
         Bounds(
-            min: Euclid.max(min, other.min),
-            max: Euclid.min(max, other.max)
+            min: Position.max(min, other.min),
+            max: Position.min(max, other.max)
         )
     }
 
@@ -166,7 +169,7 @@ public extension Bounds {
         compare(with: plane) == .spanning
     }
 
-    func containsPoint(_ p: Vector) -> Bool {
+    func containsPoint(_ p: Position) -> Bool {
         p.x >= min.x && p.x <= max.x &&
             p.y >= min.y && p.y <= max.y &&
             p.z >= min.z && p.z <= max.z

--- a/Sources/CartesianComponentsRepresentable.swift
+++ b/Sources/CartesianComponentsRepresentable.swift
@@ -131,6 +131,14 @@ public extension CartesianComponentsRepresentable {
             z: z * vn.z
         )
     }
+
+    func scaled(by f: Double) -> Self {
+        Self(
+            x: x * f,
+            y: y * f,
+            z: z * f
+        )
+    }
 }
 
 public extension CartesianComponentsRepresentable {

--- a/Sources/Euclid+CoreGraphics.swift
+++ b/Sources/Euclid+CoreGraphics.swift
@@ -39,6 +39,12 @@ public extension Vector {
     }
 }
 
+public extension Position {
+    init(_ cgPoint: CGPoint) {
+        self.init(Double(cgPoint.x), Double(cgPoint.y))
+    }
+}
+
 public extension Color {
     init(_ cgColor: CGColor) {
         let components = cgColor.components ?? [1]
@@ -49,6 +55,10 @@ public extension Color {
 public extension CGPoint {
     init(_ vector: Vector) {
         self.init(x: vector.x, y: vector.y)
+    }
+
+    init(_ position: Position) {
+        self.init(x: position.x, y: position.y)
     }
 }
 
@@ -86,7 +96,7 @@ public extension CGPath {
         typealias SafeElement = (type: CGPathElementType, points: [CGPoint])
         var paths = [Path]()
         var points = [PathPoint]()
-        var startingPoint = Vector.zero
+        var startingPoint = Position.origin
         var firstElement: SafeElement?
         var lastElement: SafeElement?
         func endPath() {
@@ -159,25 +169,25 @@ public extension CGPath {
             case .moveToPoint:
                 endPath()
                 element.points = [$0.points[0]]
-                startingPoint = Vector(element.points[0])
+                startingPoint = Position(element.points[0])
             case .closeSubpath:
                 if points.last?.position != points.first?.position {
                     points.append(points[0])
                 }
-                startingPoint = points.first?.position ?? .zero
+                startingPoint = points.first?.position ?? .origin
                 endPath()
             case .addLineToPoint:
                 let origin = $0.points[0]
                 element.points = [origin]
                 updateLastPoint(nextElement: element)
-                points.append(.point(Vector(origin)))
+                points.append(.point(Position(origin)))
             case .addQuadCurveToPoint:
                 let p1 = $0.points[0], p2 = $0.points[1]
                 element.points = [p1, p2]
                 updateLastPoint(nextElement: element)
                 guard detail > 0 else {
-                    points.append(.curve(Vector(p1)))
-                    points.append(.point(Vector(p2)))
+                    points.append(.curve(Position(p1)))
+                    points.append(.point(Position(p2)))
                     break
                 }
                 let detail = max(detail, 2)
@@ -191,15 +201,15 @@ public extension CGPath {
                         quadraticBezier(p0.position.y, Double(p1.y), Double(p2.y), t)
                     ))
                 }
-                points.append(.point(Vector(p2)))
+                points.append(.point(Position(p2)))
             case .addCurveToPoint:
                 let p1 = $0.points[0], p2 = $0.points[1], p3 = $0.points[2]
                 element.points = [p1, p2, p3]
                 updateLastPoint(nextElement: element)
                 guard detail > 0 else {
-                    points.append(.curve(Vector(p1)))
-                    points.append(.curve(Vector(p2)))
-                    points.append(.point(Vector(p3)))
+                    points.append(.curve(Position(p1)))
+                    points.append(.curve(Position(p2)))
+                    points.append(.point(Position(p3)))
                     break
                 }
                 let detail = max(detail * 2, 3)
@@ -213,7 +223,7 @@ public extension CGPath {
                         cubicBezier(p0.position.y, Double(p1.y), Double(p2.y), Double(p3.y), t)
                     ))
                 }
-                points.append(.point(Vector(p3)))
+                points.append(.point(Position(p3)))
             @unknown default:
                 return
             }

--- a/Sources/Euclid+SceneKit.swift
+++ b/Sources/Euclid+SceneKit.swift
@@ -487,6 +487,12 @@ public extension Vector {
     }
 }
 
+public extension Position {
+    init(_ v: SCNVector3) {
+        self.init(Double(v.x), Double(v.y), Double(v.z))
+    }
+}
+
 public extension Rotation {
     init(_ q: SCNQuaternion) {
         let d = sqrt(1 - Double(q.w * q.w))
@@ -512,7 +518,7 @@ public extension Transform {
 
 public extension Bounds {
     init(_ scnBoundingBox: (min: SCNVector3, max: SCNVector3)) {
-        self.init(min: Vector(scnBoundingBox.min), max: Vector(scnBoundingBox.max))
+        self.init(min: Position(scnBoundingBox.min), max: Position(scnBoundingBox.max))
     }
 }
 

--- a/Sources/Line.swift
+++ b/Sources/Line.swift
@@ -89,12 +89,12 @@ public extension Line {
     }
 
     /// Check if point is on line
-    func containsPoint(_ p: Vector) -> Bool {
+    func containsPoint(_ p: Position) -> Bool {
         abs(p.distance(from: self)) < epsilon
     }
 
     /// Distance of the line from a given point in 3D
-    func distance(from point: Vector) -> Double {
+    func distance(from point: Position) -> Double {
         distanceFromPointToLine(point, self).norm
     }
 
@@ -112,17 +112,17 @@ public extension Line {
     }
 
     /// Intersection point betwween plane and line (if any)
-    func intersection(with plane: Plane) -> Vector? {
+    func intersection(with plane: Plane) -> Position? {
         plane.intersection(with: self)
     }
 
     /// Intersection point between lines (if any)
-    func intersection(with line: Line) -> Vector? {
+    func intersection(with line: Line) -> Position? {
         lineIntersection(
-            Vector(origin),
-            Vector(origin + 1 * direction),
-            Vector(line.origin),
-            Vector(line.origin + 1 * line.direction)
+            origin,
+            origin + 1 * direction,
+            line.origin,
+            line.origin + 1 * line.direction
         )
     }
 

--- a/Sources/LineSegment.swift
+++ b/Sources/LineSegment.swift
@@ -89,16 +89,16 @@ public extension LineSegment {
 
     /// Check if point is on line segment
     func containsPoint(_ p: Position) -> Bool {
-        let v = distanceFromPointToLine(Vector(p), Line(origin: start, direction: direction))
+        let v = distanceFromPointToLine(p, Line(origin: start, direction: direction))
         guard v.norm < epsilon else {
             return false
         }
-        return lineSegmentsContainsPoint(Vector(start), Vector(end), Vector(p + v))
+        return lineSegmentsContainsPoint(start, end, p + v)
     }
 
     /// Intersection point between lines (if any)
-    func intersection(with segment: LineSegment) -> Vector? {
-        lineSegmentsIntersection(Vector(start), Vector(end), Vector(segment.start), Vector(segment.end))
+    func intersection(with segment: LineSegment) -> Position? {
+        lineSegmentsIntersection(start, end, segment.start, segment.end)
     }
 
     /// Returns true if the line segments intersect

--- a/Sources/Paths.swift
+++ b/Sources/Paths.swift
@@ -193,7 +193,7 @@ public extension Path {
 
     /// The path bounds
     var bounds: Bounds {
-        Bounds(points: points.map { $0.position })
+        Bounds(points: points.map { Position($0.position) })
     }
 
     /// Face normal for shape

--- a/Sources/Plane.swift
+++ b/Sources/Plane.swift
@@ -90,7 +90,7 @@ public extension Plane {
     /// Generate a plane from a set of coplanar points describing a polygon
     /// The polygon can be convex or concave. The direction of the plane normal is
     /// based on the assumption that the points are wound in an anticlockwise direction
-    init?(points: [Vector]) {
+    init?(points: [Position]) {
         self.init(points: points, convex: nil)
     }
 
@@ -173,21 +173,21 @@ internal extension Plane {
         self.init(normal: normal, w: Distance(pointOnPlane).dot(normal))
     }
 
-    init?(points: [Vector], convex: Bool?) {
+    init?(points: [Position], convex: Bool?) {
         guard !points.isEmpty, !pointsAreDegenerate(points) else {
             return nil
         }
         self.init(unchecked: points, convex: convex)
         // Check all points lie on this plane
-        if points.contains(where: { !containsPoint(Position($0)) }) {
+        if points.contains(where: { !containsPoint($0) }) {
             return nil
         }
     }
 
-    init(unchecked points: [Vector], convex: Bool?) {
+    init(unchecked points: [Position], convex: Bool?) {
         assert(!pointsAreDegenerate(points))
         let normal = faceNormalForPolygonPoints(points, convex: convex)
-        self.init(unchecked: normal, pointOnPlane: points[0])
+        self.init(unchecked: normal, pointOnPlane: Vector(points[0]))
     }
 
     // Approximate equality
@@ -232,7 +232,7 @@ enum FlatteningPlane: RawRepresentable {
         }
     }
 
-    init(points: [Vector], convex: Bool?) {
+    init(points: [Position], convex: Bool?) {
         self.init(normal: faceNormalForPolygonPoints(points, convex: convex))
     }
 
@@ -245,11 +245,11 @@ enum FlatteningPlane: RawRepresentable {
         }
     }
 
-    func flattenPoint(_ point: Vector) -> Vector {
+    func flattenPoint(_ point: Position) -> Position {
         switch self {
-        case .yz: return Vector(point.y, point.z)
-        case .xz: return Vector(point.x, point.z)
-        case .xy: return Vector(point.x, point.y)
+        case .yz: return Position(point.y, point.z)
+        case .xz: return Position(point.x, point.z)
+        case .xy: return Position(point.x, point.y)
         }
     }
 }

--- a/Sources/Plane.swift
+++ b/Sources/Plane.swift
@@ -154,7 +154,7 @@ public extension Plane {
     }
 
     /// Returns point intersection between plane and line
-    func intersection(with line: Line) -> Vector? {
+    func intersection(with line: Line) -> Position? {
         // https://en.wikipedia.org/wiki/Line–plane_intersection#Algebraic_form
         let lineDirectionDotPlaneNormal = line.direction.dot(normal)
         guard abs(lineDirectionDotPlaneNormal) > epsilon else {
@@ -164,7 +164,7 @@ public extension Plane {
         let planePoint = Position.origin + w * normal
         let d = (planePoint - line.origin).dot(normal) / lineDirectionDotPlaneNormal
         let intersection = line.origin + d * line.direction
-        return Vector(intersection)
+        return intersection
     }
 }
 

--- a/Sources/Polygon.swift
+++ b/Sources/Polygon.swift
@@ -84,7 +84,7 @@ extension Polygon: Codable {
     }
 
     public func encode(to encoder: Encoder) throws {
-        let positions = vertices.map { $0.position }
+        let positions = vertices.map { Position($0.position) }
         if material == nil, plane == Plane(unchecked: positions, convex: isConvex) {
             if vertices.allSatisfy({ $0.texcoord == .zero && $0.normal == plane.normal }) {
                 try positions.encode(to: encoder)
@@ -152,7 +152,7 @@ public extension Polygon {
     /// Polygon can be convex or concave, but vertices must be coplanar and non-degenerate
     /// Vertices are assumed to be in anticlockwise order for the purpose of deriving the plane
     init?(_ vertices: [Vertex], material: Material? = nil) {
-        let positions = vertices.map { $0.position }
+        let positions = vertices.map { Position($0.position) }
         let isConvex = pointsAreConvex(positions)
         guard !pointsAreSelfIntersecting(positions),
               // Note: Plane init includes check for degeneracy
@@ -182,8 +182,8 @@ public extension Polygon {
         }
         // https://stackoverflow.com/questions/217578/how-can-i-determine-whether-a-2d-point-is-within-a-polygon#218081
         let flatteningPlane = FlatteningPlane(normal: plane.normal)
-        let points = vertices.map { flatteningPlane.flattenPoint($0.position) }
-        let p = flatteningPlane.flattenPoint(p)
+        let points = vertices.map { flatteningPlane.flattenPoint(Position($0.position)) }
+        let p = flatteningPlane.flattenPoint(Position(p))
         let count = points.count
         var c = false
         var j = count - 1
@@ -383,7 +383,7 @@ internal extension Polygon {
         id: Int = 0
     ) {
         assert(!verticesAreDegenerate(vertices))
-        let points = vertices.map { $0.position }
+        let points = vertices.map { Position($0.position) }
         assert(isConvex == nil || pointsAreConvex(points) == isConvex)
         assert(sanitizeNormals || vertices.allSatisfy { $0.normal != .zero })
         let plane = plane ?? Plane(unchecked: points, convex: isConvex)

--- a/Sources/Polygon.swift
+++ b/Sources/Polygon.swift
@@ -107,7 +107,7 @@ public extension Polygon {
     /// Public properties
     var vertices: [Vertex] { storage.vertices }
     var plane: Plane { storage.plane }
-    var bounds: Bounds { Bounds(points: vertices.map { $0.position }) }
+    var bounds: Bounds { Bounds(points: vertices.map { Position($0.position) }) }
     var isConvex: Bool { storage.isConvex }
     var material: Material? {
         get { storage.material }

--- a/Sources/Position.swift
+++ b/Sources/Position.swift
@@ -18,6 +18,10 @@ public struct Position: CartesianComponentsRepresentable {
         self.y = y
         self.z = z
     }
+
+    public init(_ x: Double, _ y: Double) {
+        self.init(x, y, 0)
+    }
 }
 
 public extension Position {

--- a/Sources/Position.swift
+++ b/Sources/Position.swift
@@ -56,11 +56,42 @@ public extension Position {
     }
 }
 
+internal extension Position {
+    func compare(with plane: Plane) -> PlaneComparison {
+        let t = distance(from: plane)
+        return (t < -epsilon) ? .back : (t > epsilon) ? .front : .coplanar
+    }
+}
+
 public extension Position {
     /// Distance of the point from a plane
     /// A positive value is returned if the point lies in front of the plane
     /// A negative value is returned if the point lies behind the plane
     func distance(from plane: Plane) -> Double {
         distance.dot(plane.normal) - plane.w
+    }
+
+    /// The nearest point to this point on the specified plane
+    func project(onto plane: Plane) -> Vector {
+        let position = self - distance(from: plane) * plane.normal
+        return Vector(position)
+    }
+
+    /// Distance of the point from a line in 3D
+    func distance(from line: Line) -> Double {
+        line.distance(from: self)
+    }
+
+    /// The nearest point to this point on the specified line
+    func project(onto line: Line) -> Position {
+        self + distanceFromPointToLine(self, line)
+    }
+
+    func translated(by v: Vector) -> Position {
+        Position(x + v.x, y + v.y, z + v.z)
+    }
+
+    func transformed(by t: Transform) -> Self {
+        scaled(by: t.scale).rotated(by: t.rotation).translated(by: t.offset)
     }
 }

--- a/Sources/Shapes.swift
+++ b/Sources/Shapes.swift
@@ -256,7 +256,7 @@ public extension Mesh {
             )
         }
         let halfSize = s / 2
-        let bounds = Bounds(min: c - halfSize, max: c + halfSize)
+        let bounds = Bounds(min: Position(c - halfSize), max: Position(c + halfSize))
         switch faces {
         case .front, .default:
             return Mesh(

--- a/Sources/Transforms.swift
+++ b/Sources/Transforms.swift
@@ -406,6 +406,35 @@ public extension CartesianComponentsRepresentable {
     }
 }
 
+internal extension Collection where Element: CartesianComponentsRepresentable {
+    @_disfavoredOverload
+    func rotated(by m: Rotation) -> [Element] {
+        map { $0.rotated(by: m) }
+    }
+
+    func rotated(by q: Quaternion) -> [Element] {
+        map { $0.rotated(by: q) }
+    }
+
+    func scaled(by v: Vector) -> [Element] {
+        map { $0.scaled(by: v) }
+    }
+
+    func scaled(by f: Double) -> [Element] {
+        map { $0.scaled(by: f) }
+    }
+}
+
+internal extension Collection where Element == Position {
+    func translated(by v: Vector) -> [Position] {
+        map { $0.translated(by: v) }
+    }
+
+    func transformed(by t: Transform) -> [Position] {
+        map { $0.transformed(by: t) }
+    }
+}
+
 public extension PathPoint {
     func translated(by v: Vector) -> PathPoint {
         PathPoint(position + v, texcoord: texcoord, isCurved: isCurved)
@@ -537,7 +566,7 @@ public extension Plane {
 
 public extension Bounds {
     func translated(by v: Vector) -> Bounds {
-        Bounds(min: min + v, max: max + v)
+        Bounds(min: min + Distance(v), max: max + Distance(v))
     }
 
     @_disfavoredOverload
@@ -554,7 +583,7 @@ public extension Bounds {
     }
 
     func scaled(by f: Double) -> Bounds {
-        Bounds(min: min * f, max: max * f)
+        Bounds(min: min.scaled(by: f), max: max.scaled(by: f))
     }
 
     func transformed(by t: Transform) -> Bounds {

--- a/Sources/Transforms.swift
+++ b/Sources/Transforms.swift
@@ -437,7 +437,7 @@ internal extension Collection where Element == Position {
 
 public extension PathPoint {
     func translated(by v: Vector) -> PathPoint {
-        PathPoint(position + v, texcoord: texcoord, isCurved: isCurved)
+        PathPoint(position + Distance(v), texcoord: texcoord, isCurved: isCurved)
     }
 
     @_disfavoredOverload
@@ -454,7 +454,7 @@ public extension PathPoint {
     }
 
     func scaled(by f: Double) -> PathPoint {
-        PathPoint(position * f, texcoord: texcoord, isCurved: isCurved)
+        PathPoint(position.scaled(by: f), texcoord: texcoord, isCurved: isCurved)
     }
 
     func transformed(by t: Transform) -> PathPoint {

--- a/Sources/Utilities.swift
+++ b/Sources/Utilities.swift
@@ -34,9 +34,29 @@ let epsilon = 1e-8
 
 public extension CartesianComponentsRepresentable {
     static func == (lhs: Self, rhs: Self) -> Bool {
-        abs(lhs.x - rhs.x) < epsilon
-            && abs(lhs.y - rhs.y) < epsilon
-            && abs(lhs.z - rhs.z) < epsilon
+        if isFinite(lhs), isFinite(rhs) {
+            return abs(lhs.x - rhs.x) < epsilon
+                && abs(lhs.y - rhs.y) < epsilon
+                && abs(lhs.z - rhs.z) < epsilon
+        }
+        return areInfiniteComponentsEqual(lhs.x, rhs.x)
+            && areInfiniteComponentsEqual(lhs.y, rhs.y)
+            && areInfiniteComponentsEqual(lhs.z, rhs.z)
+    }
+
+    private static func isFinite(_ c: Self) -> Bool {
+        c.x.isFinite && c.y.isFinite && c.z.isFinite
+    }
+
+    private static func areInfiniteComponentsEqual(_ a: Double, _ b: Double) -> Bool {
+        switch (a, b) {
+        case (.infinity, .infinity):
+            return true
+        case (-Double.infinity, -Double.infinity):
+            return true
+        default:
+            return false
+        }
     }
 }
 

--- a/Sources/Utilities.swift
+++ b/Sources/Utilities.swift
@@ -428,32 +428,32 @@ func shortestLineSegmentPositionsBetween(
 
 // See "Vector formulation" at https://en.wikipedia.org/wiki/Distance_from_a_point_to_a_line
 func distanceFromPointToLine(
-    _ point: Vector,
+    _ point: Position,
     _ line: Line
 ) -> Distance {
-    let d = Position(point) - line.origin
+    let d = point - line.origin
     return d.dot(line.direction) * line.direction - d
 }
 
 func lineIntersection(
-    _ p0: Vector,
-    _ p1: Vector,
-    _ p2: Vector,
-    _ p3: Vector
-) -> Vector? {
-    guard let (p0, p1) = shortestLineSegmentPositionsBetween(Position(p0), Position(p1), Position(p2), Position(p3))
+    _ p0: Position,
+    _ p1: Position,
+    _ p2: Position,
+    _ p3: Position
+) -> Position? {
+    guard let (p0, p1) = shortestLineSegmentPositionsBetween(p0, p1, p2, p3)
     else {
         return nil
     }
-    return p0.isEqual(to: p1) ? Vector(p0) : nil
+    return p0.isEqual(to: p1) ? p0 : nil
 }
 
 func lineSegmentsIntersection(
-    _ p0: Vector,
-    _ p1: Vector,
-    _ p2: Vector,
-    _ p3: Vector
-) -> Vector? {
+    _ p0: Position,
+    _ p1: Position,
+    _ p2: Position,
+    _ p3: Position
+) -> Position? {
     guard let pi = lineIntersection(p0, p1, p2, p3) else {
         return nil // lines don't intersect
     }
@@ -464,11 +464,13 @@ func lineSegmentsIntersection(
 // Check point lies within range of line segment start/end
 // Point must already lie along the line
 func lineSegmentsContainsPoint(
-    _ start: Vector,
-    _ end: Vector,
-    _ point: Vector
+    _ start: Position,
+    _ end: Position,
+    _ point: Position
 ) -> Bool {
-    let line = Line(origin: Position(start), direction: Direction(end - start))
+    let line = Line(origin: start, direction: (end - start).direction)
     assert(distanceFromPointToLine(point, line).norm < epsilon)
-    return Bounds(min: min(start, end), max: max(start, end)).containsPoint(point)
+    let minPosition = Position.min(start, end)
+    let maxPosition = Position.max(start, end)
+    return Bounds(min: minPosition, max: maxPosition).containsPoint(point)
 }

--- a/Sources/Vector.swift
+++ b/Sources/Vector.swift
@@ -218,22 +218,6 @@ public extension Vector {
         let complementeryAngle = Direction(self).dot(plane.normal)
         return Angle.asin(complementeryAngle)
     }
-
-    /// The nearest point to this point on the specified plane
-    func project(onto plane: Plane) -> Vector {
-        let position = Position(self) - Position(self).distance(from: plane) * plane.normal
-        return Vector(position)
-    }
-
-    /// Distance of the point from a line in 3D
-    func distance(from line: Line) -> Double {
-        line.distance(from: self)
-    }
-
-    /// The nearest point to this point on the specified line
-    func project(onto line: Line) -> Vector {
-        self + Vector(distanceFromPointToLine(self, line))
-    }
 }
 
 internal extension Vector {

--- a/Tests/BoundsTests.swift
+++ b/Tests/BoundsTests.swift
@@ -13,28 +13,28 @@ class BoundsTests: XCTestCase {
     // MARK: Union
 
     func testUnionOfCoincidingBounds() {
-        let a = Bounds(min: Vector(-1, -1, -1), max: Vector(1, 1, 1))
-        let b = Bounds(min: Vector(-1, -1, -1), max: Vector(1, 1, 1))
+        let a = Bounds(min: Position(-1, -1, -1), max: Position(1, 1, 1))
+        let b = Bounds(min: Position(-1, -1, -1), max: Position(1, 1, 1))
         let c = a.union(b)
         XCTAssertEqual(c, a)
     }
 
     func testUnionOfAdjacentBounds() {
-        let a = Bounds(min: Vector(-1, -0.5, -0.5), max: Vector(0, 0.5, 0.5))
-        let b = Bounds(min: Vector(0, -0.5, -0.5), max: Vector(1, 0.5, 0.5))
-        let c = Bounds(min: Vector(-1, -0.5, -0.5), max: Vector(1, 0.5, 0.5))
+        let a = Bounds(min: Position(-1, -0.5, -0.5), max: Position(0, 0.5, 0.5))
+        let b = Bounds(min: Position(0, -0.5, -0.5), max: Position(1, 0.5, 0.5))
+        let c = Bounds(min: Position(-1, -0.5, -0.5), max: Position(1, 0.5, 0.5))
         XCTAssertEqual(a.union(b), c)
     }
 
     func testUnionOfEmptyAndBounds() {
         let a = Bounds.empty
-        let b = Bounds(min: Vector(-1, -1, -1), max: Vector(1, 1, 1))
+        let b = Bounds(min: Position(-1, -1, -1), max: Position(1, 1, 1))
         let c = a.union(b)
         XCTAssertEqual(c, b)
     }
 
     func testUnionOfBoundsAndEmpty() {
-        let a = Bounds(min: Vector(-1, -1, -1), max: Vector(1, 1, 1))
+        let a = Bounds(min: Position(-1, -1, -1), max: Position(1, 1, 1))
         let b = Bounds.empty
         let c = a.union(b)
         XCTAssertEqual(c, a)
@@ -43,28 +43,28 @@ class BoundsTests: XCTestCase {
     // MARK: Intersection
 
     func testIntersectionOfCoincidingBounds() {
-        let a = Bounds(min: Vector(-1, -1, -1), max: Vector(1, 1, 1))
-        let b = Bounds(min: Vector(-1, -1, -1), max: Vector(1, 1, 1))
+        let a = Bounds(min: Position(-1, -1, -1), max: Position(1, 1, 1))
+        let b = Bounds(min: Position(-1, -1, -1), max: Position(1, 1, 1))
         let c = a.intersection(b)
         XCTAssertEqual(c, a)
     }
 
     func testIntersectionOfAdjacentBounds() {
-        let a = Bounds(min: Vector(-1, -0.5, -0.5), max: Vector(0, 0.5, 0.5))
-        let b = Bounds(min: Vector(0, -0.5, -0.5), max: Vector(1, 0.5, 0.5))
-        let c = Bounds(min: Vector(0, -0.5, -0.5), max: Vector(0, 0.5, 0.5))
+        let a = Bounds(min: Position(-1, -0.5, -0.5), max: Position(0, 0.5, 0.5))
+        let b = Bounds(min: Position(0, -0.5, -0.5), max: Position(1, 0.5, 0.5))
+        let c = Bounds(min: Position(0, -0.5, -0.5), max: Position(0, 0.5, 0.5))
         XCTAssertEqual(a.intersection(b), c)
     }
 
     func testIntersectionOfEmptyAndBounds() {
         let a = Bounds.empty
-        let b = Bounds(min: Vector(-1, -1, -1), max: Vector(1, 1, 1))
+        let b = Bounds(min: Position(-1, -1, -1), max: Position(1, 1, 1))
         let c = a.intersection(b)
         XCTAssertEqual(c, .empty)
     }
 
     func testIntersectionOfBoundsAndEmpty() {
-        let a = Bounds(min: Vector(-1, -1, -1), max: Vector(1, 1, 1))
+        let a = Bounds(min: Position(-1, -1, -1), max: Position(1, 1, 1))
         let b = Bounds.empty
         let c = a.intersection(b)
         XCTAssertEqual(c, .empty)
@@ -78,42 +78,42 @@ class BoundsTests: XCTestCase {
     }
 
     func testNegativeVolumeBoundsIsEmpty() {
-        let bounds = Bounds(min: Vector(1, 1, 1), max: Vector(-1, -1, -1))
+        let bounds = Bounds(min: Position(1, 1, 1), max: Position(-1, -1, -1))
         XCTAssert(bounds.isEmpty)
     }
 
     func testZeroSizedBoundsIsEmpty() {
-        let bounds = Bounds(min: .zero, max: .zero)
+        let bounds = Bounds(min: .origin, max: .origin)
         XCTAssert(bounds.isEmpty)
     }
 
     func testBoundsWithNegativeWidthIsEmpty() {
-        let bounds = Bounds(min: .zero, max: Vector(-1, 1, 1))
+        let bounds = Bounds(min: .origin, max: Position(-1, 1, 1))
         XCTAssert(bounds.isEmpty)
     }
 
     func testBoundsWithZeroWidthIsNotEmpty() {
-        let bounds = Bounds(min: .zero, max: Vector(0, 1, 1))
+        let bounds = Bounds(min: .origin, max: Position(0, 1, 1))
         XCTAssertFalse(bounds.isEmpty)
     }
 
     func testBoundsWithNegativeHeightIsEmpty() {
-        let bounds = Bounds(min: .zero, max: Vector(1, -1, 1))
+        let bounds = Bounds(min: .origin, max: Position(1, -1, 1))
         XCTAssert(bounds.isEmpty)
     }
 
     func testBoundsWithZeroHeightIsNotEmpty() {
-        let bounds = Bounds(min: .zero, max: Vector(1, 0, 1))
+        let bounds = Bounds(min: .origin, max: Position(1, 0, 1))
         XCTAssertFalse(bounds.isEmpty)
     }
 
     func testBoundsWithNegativeDepthIsEmpty() {
-        let bounds = Bounds(min: .zero, max: Vector(1, 1, -1))
+        let bounds = Bounds(min: .origin, max: Position(1, 1, -1))
         XCTAssert(bounds.isEmpty)
     }
 
     func testBoundsWithZeroDepthIsNotEmpty() {
-        let bounds = Bounds(min: .zero, max: Vector(1, 1, 0))
+        let bounds = Bounds(min: .origin, max: Position(1, 1, 0))
         XCTAssertFalse(bounds.isEmpty)
     }
 }

--- a/Tests/CSGTests.swift
+++ b/Tests/CSGTests.swift
@@ -38,8 +38,8 @@ class CSGTests: XCTestCase {
         let b = Mesh.cube().translated(by: Vector(0.5, 0, 0))
         let c = a.subtract(b)
         XCTAssertEqual(c.bounds, Bounds(
-            min: Vector(-0.5, -0.5, -0.5),
-            max: Vector(0, 0.5, 0.5)
+            min: Position(-0.5, -0.5, -0.5),
+            max: Position(0, 0.5, 0.5)
         ))
     }
 
@@ -71,8 +71,8 @@ class CSGTests: XCTestCase {
         let b = Mesh.cube().translated(by: Vector(0.5, 0, 0))
         let c = a.xor(b)
         XCTAssertEqual(c.bounds, Bounds(
-            min: Vector(-0.5, -0.5, -0.5),
-            max: Vector(1.0, 0.5, 0.5)
+            min: Position(-0.5, -0.5, -0.5),
+            max: Position(1.0, 0.5, 0.5)
         ))
     }
 
@@ -104,8 +104,8 @@ class CSGTests: XCTestCase {
         let b = Mesh.cube().translated(by: Vector(0.5, 0, 0))
         let c = a.union(b)
         XCTAssertEqual(c.bounds, Bounds(
-            min: Vector(-0.5, -0.5, -0.5),
-            max: Vector(1, 0.5, 0.5)
+            min: Position(-0.5, -0.5, -0.5),
+            max: Position(1, 0.5, 0.5)
         ))
     }
 
@@ -132,8 +132,8 @@ class CSGTests: XCTestCase {
         // TODO: ideally this should probably be empty, but it's not clear
         // how to achieve that while also getting desired planar behavior
         XCTAssertEqual(c.bounds, Bounds(
-            min: Vector(0.5, -0.5, -0.5),
-            max: Vector(0.5, 0.5, 0.5)
+            min: Position(0.5, -0.5, -0.5),
+            max: Position(0.5, 0.5, 0.5)
         ))
     }
 
@@ -142,8 +142,8 @@ class CSGTests: XCTestCase {
         let b = Mesh.cube().translated(by: Vector(0.5, 0, 0))
         let c = a.intersect(b)
         XCTAssertEqual(c.bounds, Bounds(
-            min: Vector(0, -0.5, -0.5),
-            max: Vector(0.5, 0.5, 0.5)
+            min: Position(0, -0.5, -0.5),
+            max: Position(0.5, 0.5, 0.5)
         ))
     }
 
@@ -175,8 +175,8 @@ class CSGTests: XCTestCase {
         let b = Mesh.fill(.square()).translated(by: Vector(0.5, 0, 0))
         let c = a.subtract(b)
         XCTAssertEqual(c.bounds, Bounds(
-            min: Vector(-0.5, -0.5, 0),
-            max: Vector(0, 0.5, 0)
+            min: Position(-0.5, -0.5, 0),
+            max: Position(0, 0.5, 0)
         ))
     }
 
@@ -201,8 +201,8 @@ class CSGTests: XCTestCase {
         let b = Mesh.fill(.square()).translated(by: Vector(0.5, 0, 0))
         let c = a.xor(b)
         XCTAssertEqual(c.bounds, Bounds(
-            min: Vector(-0.5, -0.5, 0),
-            max: Vector(1.0, 0.5, 0)
+            min: Position(-0.5, -0.5, 0),
+            max: Position(1.0, 0.5, 0)
         ))
     }
 
@@ -227,8 +227,8 @@ class CSGTests: XCTestCase {
         let b = Mesh.fill(.square()).translated(by: Vector(0.5, 0, 0))
         let c = a.union(b)
         XCTAssertEqual(c.bounds, Bounds(
-            min: Vector(-0.5, -0.5, 0),
-            max: Vector(1, 0.5, 0)
+            min: Position(-0.5, -0.5, 0),
+            max: Position(1, 0.5, 0)
         ))
     }
 
@@ -253,8 +253,8 @@ class CSGTests: XCTestCase {
         let b = Mesh.fill(.square()).translated(by: Vector(0.5, 0, 0))
         let c = a.intersect(b)
         XCTAssertEqual(c.bounds, Bounds(
-            min: Vector(0, -0.5, 0),
-            max: Vector(0.5, 0.5, 0)
+            min: Position(0, -0.5, 0),
+            max: Position(0.5, 0.5, 0)
         ))
     }
 }

--- a/Tests/CodingTests.swift
+++ b/Tests/CodingTests.swift
@@ -713,7 +713,7 @@ class CodingTests: XCTestCase {
     }
 
     func testEncodingPathPoint2D() throws {
-        let encoded = try encode(PathPoint.point(Vector(1, 2)))
+        let encoded = try encode(PathPoint.point(Position(1, 2)))
         XCTAssertEqual(encoded, "[1,2]")
     }
 
@@ -722,7 +722,7 @@ class CodingTests: XCTestCase {
     }
 
     func testEncodingPathPoint3D() throws {
-        let encoded = try encode(PathPoint.point(Vector(1, 2, 3)))
+        let encoded = try encode(PathPoint.point(Position(1, 2, 3)))
         XCTAssertEqual(encoded, "[1,2,3]")
     }
 
@@ -731,7 +731,7 @@ class CodingTests: XCTestCase {
     }
 
     func testEncodingCurvedPathPoint2D() throws {
-        let encoded = try encode(PathPoint.curve(Vector(1, 2)))
+        let encoded = try encode(PathPoint.curve(Position(1, 2)))
         XCTAssertEqual(encoded, "[1,2,true]")
     }
 
@@ -740,84 +740,84 @@ class CodingTests: XCTestCase {
     }
 
     func testEncodingCurvedPathPoint3D() throws {
-        let encoded = try encode(PathPoint.curve(Vector(1, 2, 3)))
+        let encoded = try encode(PathPoint.curve(Position(1, 2, 3)))
         XCTAssertEqual(encoded, "[1,2,3,true]")
     }
 
     func testDecodingPathPoint2DWithTexcoord() {
         XCTAssertEqual(
             try decode("[1, 2, 3, 4]"),
-            PathPoint.point(Vector(1, 2), texcoord: Vector(3, 4))
+            PathPoint.point(Position(1, 2), texcoord: Vector(3, 4))
         )
     }
 
     func testEncodingPathPoint2DWithTexcoord() throws {
-        let encoded = try encode(PathPoint.point(Vector(1, 2), texcoord: Vector(3, 4)))
+        let encoded = try encode(PathPoint.point(Position(1, 2), texcoord: Vector(3, 4)))
         XCTAssertEqual(encoded, "[1,2,3,4]")
     }
 
     func testDecodingPathPoint3DWithTexcoord() {
         XCTAssertEqual(
             try decode("[1, 2, 3, 4, 5]"),
-            PathPoint.point(Vector(1, 2, 3), texcoord: Vector(4, 5))
+            PathPoint.point(Position(1, 2, 3), texcoord: Vector(4, 5))
         )
     }
 
     func testDecodingPathPoint3DWithTexcoord3D() {
         XCTAssertEqual(
             try decode("[1, 2, 3, 4, 5, 6]"),
-            PathPoint.point(Vector(1, 2, 3), texcoord: Vector(4, 5, 6))
+            PathPoint.point(Position(1, 2, 3), texcoord: Vector(4, 5, 6))
         )
     }
 
     func testEncodingPathPoint3DWithTexcoord() throws {
-        let encoded = try encode(PathPoint.point(Vector(1, 2, 3), texcoord: Vector(4, 5)))
+        let encoded = try encode(PathPoint.point(Position(1, 2, 3), texcoord: Vector(4, 5)))
         XCTAssertEqual(encoded, "[1,2,3,4,5]")
     }
 
     func testEncodingPathPoint3DWithTexcoord3D() throws {
-        let encoded = try encode(PathPoint.point(Vector(1, 2, 3), texcoord: Vector(4, 5, 6)))
+        let encoded = try encode(PathPoint.point(Position(1, 2, 3), texcoord: Vector(4, 5, 6)))
         XCTAssertEqual(encoded, "[1,2,3,4,5,6]")
     }
 
     func testDecodingCurvedPathPoint2DWithTexcoord() {
         XCTAssertEqual(
             try decode("[1, 2, 3, 4, true]"),
-            PathPoint.curve(Vector(1, 2), texcoord: Vector(3, 4))
+            PathPoint.curve(Position(1, 2), texcoord: Vector(3, 4))
         )
     }
 
     func testEncodingCurvedPathPoint2DWithTexcoord() throws {
-        let encoded = try encode(PathPoint.curve(Vector(1, 2), texcoord: Vector(3, 4)))
+        let encoded = try encode(PathPoint.curve(Position(1, 2), texcoord: Vector(3, 4)))
         XCTAssertEqual(encoded, "[1,2,3,4,true]")
     }
 
     func testEncodingCurvedPathPoint2DWithTexcoord3D() throws {
-        let encoded = try encode(PathPoint.curve(Vector(1, 2), texcoord: Vector(3, 4, 5)))
+        let encoded = try encode(PathPoint.curve(Position(1, 2), texcoord: Vector(3, 4, 5)))
         XCTAssertEqual(encoded, "[1,2,0,3,4,5,true]")
     }
 
     func testDecodingCurvedPathPoint3DWithTexcoord() {
         XCTAssertEqual(
             try decode("[1, 2, 3, 4, 5, true]"),
-            PathPoint.curve(Vector(1, 2, 3), texcoord: Vector(4, 5))
+            PathPoint.curve(Position(1, 2, 3), texcoord: Vector(4, 5))
         )
     }
 
     func testDecodingCurvedPathPoint3DWithTexcoord3D() {
         XCTAssertEqual(
             try decode("[1, 2, 3, 4, 5, 6, true]"),
-            PathPoint.curve(Vector(1, 2, 3), texcoord: Vector(4, 5, 6))
+            PathPoint.curve(Position(1, 2, 3), texcoord: Vector(4, 5, 6))
         )
     }
 
     func testEncodingCurvedPathPoint3DWithTexcoord() throws {
-        let encoded = try encode(PathPoint.curve(Vector(1, 2, 3), texcoord: Vector(4, 5)))
+        let encoded = try encode(PathPoint.curve(Position(1, 2, 3), texcoord: Vector(4, 5)))
         XCTAssertEqual(encoded, "[1,2,3,4,5,true]")
     }
 
     func testEncodingCurvedPathPoint3DWithTexcoord3D() throws {
-        let encoded = try encode(PathPoint.curve(Vector(1, 2, 3), texcoord: Vector(4, 5, 6)))
+        let encoded = try encode(PathPoint.curve(Position(1, 2, 3), texcoord: Vector(4, 5, 6)))
         XCTAssertEqual(encoded, "[1,2,3,4,5,6,true]")
     }
 

--- a/Tests/LineTests.swift
+++ b/Tests/LineTests.swift
@@ -14,13 +14,13 @@ class LineTests: XCTestCase {
 
     func testDistanceFromPointSimple() {
         let l = Line(origin: .origin, direction: .x)
-        let p = Vector(15, 2, 0)
+        let p = Position(15, 2, 0)
         XCTAssertEqual(l.distance(from: p), 2)
     }
 
     func testDistanceFromPointHarder() {
         let l = Line(origin: .origin, direction: .x)
-        let p = Vector(15, 2, 3)
+        let p = Position(15, 2, 3)
         XCTAssertEqual(l.distance(from: p), (2 * 2 + 3 * 3).squareRoot())
     }
 
@@ -28,32 +28,32 @@ class LineTests: XCTestCase {
 
     func testProjectPointDown() {
         let l = Line(origin: .origin, direction: .x)
-        let p = Vector(2, -2, 0)
-        XCTAssertEqual(p.project(onto: l), Vector(2, 0, 0))
+        let p = Position(2, -2, 0)
+        XCTAssertEqual(p.project(onto: l), Position(2, 0, 0))
     }
 
     func testProjectPointUp() {
         let l = Line(origin: .origin, direction: .x)
-        let p = Vector(3, 1, 0)
-        XCTAssertEqual(p.project(onto: l), Vector(3, 0, 0))
+        let p = Position(3, 1, 0)
+        XCTAssertEqual(p.project(onto: l), Position(3, 0, 0))
     }
 
     func testProjectPointRight() {
         let l = Line(origin: .origin, direction: .y)
-        let p = Vector(-3, 1, 0)
-        XCTAssertEqual(p.project(onto: l), Vector(0, 1, 0))
+        let p = Position(-3, 1, 0)
+        XCTAssertEqual(p.project(onto: l), Position(0, 1, 0))
     }
 
     func testProjectPointLeft() {
         let l = Line(origin: .origin, direction: .y)
-        let p = Vector(3, -5, 0)
-        XCTAssertEqual(p.project(onto: l), Vector(0, -5, 0))
+        let p = Position(3, -5, 0)
+        XCTAssertEqual(p.project(onto: l), Position(0, -5, 0))
     }
 
     func testProjectPointDiagonal() {
         let l = Line(origin: .origin, direction: Direction(1, 1, 0))
-        let p = Vector(0, 2, 0)
-        XCTAssert(p.project(onto: l).isEqual(to: Vector(1, 1, 0)))
+        let p = Position(0, 2, 0)
+        XCTAssert(p.project(onto: l).isEqual(to: Position(1, 1, 0)))
     }
 
     // MARK: Line intersection
@@ -63,7 +63,7 @@ class LineTests: XCTestCase {
         let l2 = Line(origin: Position(0, 1, 3), direction: -.y)
 
         let intersection = l1.intersection(with: l2)
-        XCTAssertEqual(intersection, Vector(0, 0, 3))
+        XCTAssertEqual(intersection, Position(0, 0, 3))
     }
 
     func testLineIntersectionXZ() {
@@ -71,7 +71,7 @@ class LineTests: XCTestCase {
         let l2 = Line(origin: Position(0, 3, 1), direction: -.z)
 
         let intersection = l1.intersection(with: l2)
-        XCTAssertEqual(intersection, Vector(0, 3, 0))
+        XCTAssertEqual(intersection, Position(0, 3, 0))
     }
 
     func testLineIntersectionYZ() {
@@ -79,7 +79,7 @@ class LineTests: XCTestCase {
         let l2 = Line(origin: Position(3, 0, 1), direction: -.z)
 
         let intersection = l1.intersection(with: l2)
-        XCTAssertEqual(intersection, Vector(3, 0, 0))
+        XCTAssertEqual(intersection, Position(3, 0, 0))
     }
 
     func testCoincidentLineIntersection() {
@@ -91,17 +91,17 @@ class LineTests: XCTestCase {
 
     func testContainsPoint() {
         let line = Line(origin: Position(-2, -1, 0), direction: Direction(2, 1, 0))
-        XCTAssert(line.containsPoint(Vector(-1, -0.5, 0)))
+        XCTAssert(line.containsPoint(Position(-1, -0.5, 0)))
     }
 
     func testContainsPoint2() {
         let line = Line(origin: Position(-2, -1, 0), direction: Direction(2, 1, 0))
-        XCTAssert(line.containsPoint(Vector(-3, -1.5, 0)))
+        XCTAssert(line.containsPoint(Position(-3, -1.5, 0)))
     }
 
     func testDoesNotContainPoint() {
         let line = Line(origin: Position(-2, -1, 0), direction: Direction(2, 1, 0))
-        XCTAssertFalse(line.containsPoint(Vector(-1, -0.6, 0)))
+        XCTAssertFalse(line.containsPoint(Position(-1, -0.6, 0)))
     }
 
     // MARK: Equality

--- a/Tests/PlaneTests.swift
+++ b/Tests/PlaneTests.swift
@@ -179,21 +179,21 @@ class PlaneTests: XCTestCase {
     func testIntersectWithNormalLine() {
         let line = Line(origin: Position(1, 5, 60), direction: .z)
         let plane = Plane(unchecked: .z, pointOnPlane: Vector(-3, 2, 0))
-        let expected = Vector(1, 5, 0)
+        let expected = Position(1, 5, 0)
         XCTAssertEqual(expected, plane.intersection(with: line))
     }
 
     func testIntersectionWithAxisLine() {
         let line = Line(origin: .origin, direction: Direction(4, 3, 0))
         let plane = Plane(normal: .y, w: 3)
-        let expected = Vector(4, 3, 0)
+        let expected = Position(4, 3, 0)
         XCTAssertEqual(expected, plane.intersection(with: line))
     }
 
     func testIntersectionWithSkewedLine() {
         let line = Line(origin: Position(8, 8, 10), direction: Direction(1, 1, 1))
         let plane = Plane(unchecked: .z, pointOnPlane: Vector(5, -7, 2))
-        let expected = Vector(0, 0, 2)
+        let expected = Position(0, 0, 2)
         XCTAssertEqual(expected, plane.intersection(with: line))
     }
 }

--- a/Tests/PlaneTests.swift
+++ b/Tests/PlaneTests.swift
@@ -12,12 +12,12 @@ import XCTest
 class PlaneTests: XCTestCase {
     func testConcavePolygonClockwiseWinding() {
         var transform = Transform.identity
-        var points = [Vector]()
+        var points = [Position]()
         let sides = 5
         for _ in 0 ..< sides {
-            points.append(Vector(0, -0.5).transformed(by: transform))
+            points.append(Position(0, -0.5).transformed(by: transform))
             transform.rotate(by: .roll(.pi / Double(sides)))
-            points.append(Vector(0, -1).transformed(by: transform))
+            points.append(Position(0, -1).transformed(by: transform))
             transform.rotate(by: .roll(.pi / Double(sides)))
         }
         let plane = Plane(points: points)!
@@ -25,13 +25,13 @@ class PlaneTests: XCTestCase {
     }
 
     func testConcavePolygonPlaneTranslation() {
-        let points0: [Vector] = [
-            Vector(-0.707106781187, -0.707106781187, 0.5),
-            Vector(0.353553390593, 0.353553390593, 0.5),
-            Vector(0.353553390593, 0.353553390593, 0),
-            Vector(0.707106781187, 0.707106781187, 0),
-            Vector(0.707106781187, 0.707106781187, 1),
-            Vector(-0.707106781187, -0.707106781187, 1),
+        let points0: [Position] = [
+            Position(-0.707106781187, -0.707106781187, 0.5),
+            Position(0.353553390593, 0.353553390593, 0.5),
+            Position(0.353553390593, 0.353553390593, 0),
+            Position(0.707106781187, 0.707106781187, 0),
+            Position(0.707106781187, 0.707106781187, 1),
+            Position(-0.707106781187, -0.707106781187, 1),
         ]
         let plane0 = Plane(points: points0)
         let translation = Vector(1, 0)
@@ -70,13 +70,13 @@ class PlaneTests: XCTestCase {
     }
 
     func testFlatteningPlaneForHorizontalLine() {
-        let points = [Vector(-1, 0), Vector(1, 0)]
+        let points = [Position(-1, 0), Position(1, 0)]
         let plane = FlatteningPlane(points: points, convex: nil)
         XCTAssertEqual(plane, .xy)
     }
 
     func testFlatteningPlaneForVerticalLine() {
-        let points = [Vector(0, -1), Vector(0, 1)]
+        let points = [Position(0, -1), Position(0, 1)]
         let plane = FlatteningPlane(points: points, convex: nil)
         XCTAssertEqual(plane, .xy)
     }

--- a/Tests/ShapeTests.swift
+++ b/Tests/ShapeTests.swift
@@ -225,7 +225,7 @@ class ShapeTests: XCTestCase {
         // Every vertex in the loft should be contained by one of our shapes
         let vertices = loft.polygons.flatMap { $0.vertices }
         XCTAssert(vertices.allSatisfy { vertex in
-            shapes.contains(where: { $0.points.contains(where: { $0.position == vertex.position }) })
+            shapes.contains(where: { $0.points.contains(where: { $0.position == Position(vertex.position) }) })
         })
     }
 
@@ -248,7 +248,7 @@ class ShapeTests: XCTestCase {
         // Every vertex in the loft should be contained by one of our shapes
         let vertices = loft.polygons.flatMap { $0.vertices }
         XCTAssert(vertices.allSatisfy { vertex in
-            shapes.contains(where: { $0.points.contains(where: { $0.position == vertex.position }) })
+            shapes.contains(where: { $0.points.contains(where: { $0.position == Position(vertex.position) }) })
         })
     }
 

--- a/Tests/UtilityTests.swift
+++ b/Tests/UtilityTests.swift
@@ -116,7 +116,7 @@ class UtilityTests: XCTestCase {
 
     func testVectorFromPointToLine() {
         let result = distanceFromPointToLine(
-            Vector(2, 0),
+            Position(2, 0, 0),
             Line(origin: Position(x: -1, y: -1, z: 0), direction: .x)
         )
         XCTAssertEqual(result, Distance(0, -1, 0))

--- a/Tests/UtilityTests.swift
+++ b/Tests/UtilityTests.swift
@@ -14,24 +14,24 @@ class UtilityTests: XCTestCase {
 
     func testConvexnessResultNotAffectedByTranslation() {
         let vectors = [
-            Vector(-0.10606601717798211, 0, -0.10606601717798216),
-            Vector(-0.0574025148547635, 0, -0.138581929876693),
-            Vector(-0.15648794521398243, 0, -0.1188726123511085),
-            Vector(-0.16970931752558446, 0, -0.09908543035921899),
-            Vector(-0.16346853203274558, 0, -0.06771088298918408),
+            Position(-0.10606601717798211, 0, -0.10606601717798216),
+            Position(-0.0574025148547635, 0, -0.138581929876693),
+            Position(-0.15648794521398243, 0, -0.1188726123511085),
+            Position(-0.16970931752558446, 0, -0.09908543035921899),
+            Position(-0.16346853203274558, 0, -0.06771088298918408),
         ]
         XCTAssertTrue(pointsAreConvex(vectors))
         let offset = Vector(0, 0, 3)
-        let vertices = vectors.map { Vertex($0, .y).translated(by: offset) }
+        let vertices = vectors.map { Vertex(Vector($0), .y).translated(by: offset) }
         XCTAssertTrue(verticesAreConvex(vertices))
     }
 
     func testColinearPointsDontPreventConvexness() {
         let vectors = [
-            Vector(0, 1),
-            Vector(0, 0),
-            Vector(0, -1),
-            Vector(1, -1),
+            Position(0, 1),
+            Position(0, 0),
+            Position(0, -1),
+            Position(1, -1),
         ]
         XCTAssertTrue(pointsAreConvex(vectors))
     }
@@ -125,17 +125,17 @@ class UtilityTests: XCTestCase {
     // MARK: faceNormalForPolygonPoints
 
     func testFaceNormalForZAxisLine() {
-        let result = faceNormalForPolygonPoints([.zero, Vector(0, 0, 1)], convex: nil)
+        let result = faceNormalForPolygonPoints([.origin, Position(0, 0, 1)], convex: nil)
         XCTAssertEqual(result, .x)
     }
 
     func testFaceNormalForVerticalLine() {
-        let result = faceNormalForPolygonPoints([.zero, Vector(0, 1, 0)], convex: nil)
+        let result = faceNormalForPolygonPoints([.origin, Position(0, 1, 0)], convex: nil)
         XCTAssertEqual(result, .z)
     }
 
     func testFaceNormalForHorizontalLine() {
-        let result = faceNormalForPolygonPoints([.zero, Vector(1, 0, 0)], convex: nil)
+        let result = faceNormalForPolygonPoints([.origin, Position(1, 0, 0)], convex: nil)
         XCTAssertEqual(result, .z)
     }
 }


### PR DESCRIPTION
Overview of remaining refactoring steps from #37:

`line.origin` -> `Position` _[done]_
`lineSegment.start/end` -> `Position` _[done]_
`pathPoint.position` -> `Position` **[this PR]**
`transform.offset` -> `Distance` _[pending]_
`transform.scale` -> `Distance` _[pending]_
`vertex.position` -> `Position` _[pending]_
`Plane(normal: Direction, pointOnPlane: Vector)` -> `pointOnPlane` should be `Position` _[pending]_