### PR TITLE
Vector semantics: transform offset (4/7)

### DIFF
--- a/Sources/CSG.swift
+++ b/Sources/CSG.swift
@@ -336,7 +336,7 @@ public extension Mesh {
                 material: material
             )
             .rotated(by: rotation)
-            .translated(by: Vector(plane.w * plane.normal))
+            .translated(by: plane.w * plane.normal)
             // Clip rect
             return Mesh(
                 unchecked: mesh.polygons + BSP(self) { false }

--- a/Sources/Distance.swift
+++ b/Sources/Distance.swift
@@ -18,6 +18,10 @@ public struct Distance: AdditiveArithmeticCartesianComponentsRepresentable {
         self.y = y
         self.z = z
     }
+    
+    public init(_ x: Double, _ y: Double) {
+        self.init(x, y, 0)
+    }
 }
 
 public extension Distance {

--- a/Sources/Euclid+CoreGraphics.swift
+++ b/Sources/Euclid+CoreGraphics.swift
@@ -45,6 +45,12 @@ public extension Position {
     }
 }
 
+public extension Distance {
+    init(_ cgPoint: CGPoint) {
+        self.init(Double(cgPoint.x), Double(cgPoint.y))
+    }
+}
+
 public extension Color {
     init(_ cgColor: CGColor) {
         let components = cgColor.components ?? [1]
@@ -59,6 +65,10 @@ public extension CGPoint {
 
     init(_ position: Position) {
         self.init(x: position.x, y: position.y)
+    }
+    
+    init(_ distance: Distance) {
+        self.init(x: distance.x, y: distance.y)
     }
 }
 

--- a/Sources/Euclid+CoreText.swift
+++ b/Sources/Euclid+CoreText.swift
@@ -101,7 +101,7 @@ public extension Mesh {
         var meshes = [Mesh]()
         var cache = [CGPath: Mesh]()
         for (cgPath, cgPoint) in cgPaths(for: text, width: width) {
-            let offset = Vector(cgPoint)
+            let offset = Distance(cgPoint)
             guard let mesh = cache[cgPath] else {
                 let path = Path(cgPath: cgPath)
                 let mesh = Mesh.extrude(path, depth: depth, material: material)

--- a/Sources/Euclid+SceneKit.swift
+++ b/Sources/Euclid+SceneKit.swift
@@ -37,6 +37,10 @@ public extension SCNVector3 {
     init(_ v: Vector) {
         self.init(v.x, v.y, v.z)
     }
+    
+    init<T: CartesianComponentsRepresentable>(_ cartesian: T) {
+        self.init(cartesian.x, cartesian.y, cartesian.z)
+    }
 }
 
 public extension SCNQuaternion {
@@ -487,7 +491,7 @@ public extension Vector {
     }
 }
 
-public extension Position {
+public extension CartesianComponentsRepresentable {
     init(_ v: SCNVector3) {
         self.init(Double(v.x), Double(v.y), Double(v.z))
     }
@@ -509,7 +513,7 @@ public extension Rotation {
 public extension Transform {
     static func transform(from scnNode: SCNNode) -> Transform {
         Transform(
-            offset: Vector(scnNode.position),
+            offset: Distance(scnNode.position),
             rotation: Rotation(scnNode.orientation),
             scale: Vector(scnNode.scale)
         )

--- a/Sources/Position.swift
+++ b/Sources/Position.swift
@@ -91,7 +91,7 @@ public extension Position {
         self + distanceFromPointToLine(self, line)
     }
 
-    func translated(by v: Vector) -> Position {
+    func translated(by v: Distance) -> Position {
         Position(x + v.x, y + v.y, z + v.z)
     }
 

--- a/Sources/Quaternion.swift
+++ b/Sources/Quaternion.swift
@@ -64,19 +64,19 @@ public extension Quaternion {
 
     /// Define a rotation around the X axis
     static func pitch(_ rotation: Angle) -> Quaternion {
-        let r = -rotation.radians * 0.5
+        let r = -rotation * 0.5
         return Quaternion(sin(r), 0, 0, cos(r))
     }
 
     /// Define a rotation around the Y axis
     static func yaw(_ rotation: Angle) -> Quaternion {
-        let r = -rotation.radians * 0.5
+        let r = -rotation * 0.5
         return Quaternion(0, sin(r), 0, cos(r))
     }
 
     /// Define a rotation around the Z axis
     static func roll(_ rotation: Angle) -> Quaternion {
-        let r = -rotation.radians * 0.5
+        let r = -rotation * 0.5
         return Quaternion(0, 0, sin(r), cos(r))
     }
 

--- a/Sources/Shapes.swift
+++ b/Sources/Shapes.swift
@@ -418,7 +418,7 @@ public extension Mesh {
         faces: Faces = .default,
         material: Material? = nil
     ) -> Mesh {
-        let offset = Vector(shape.faceNormal) * (depth / 2)
+        let offset = (depth / 2) * shape.faceNormal
         if offset.isEqual(to: .zero) {
             return fill(shape, faces: faces, material: material)
         }
@@ -485,7 +485,7 @@ public extension Mesh {
             }
             shape = shape.rotated(by: r)
             if p0p1.isEqual(to: p1p2) {
-                shapes.append(shape.translated(by: Vector(p1.position)))
+                shapes.append(shape.translated(by: p1.position.distance))
             } else {
                 let axis = p0p1.cross(p1p2)
                 let a = (1 / p0p1.dot(p0p2)) - 1
@@ -494,7 +494,7 @@ public extension Mesh {
                 scale.y = abs(scale.y)
                 scale.z = abs(scale.z)
                 scale = scale + Vector(1, 1, 1)
-                shapes.append(shape.scaled(by: scale).translated(by: Vector(p1.position)))
+                shapes.append(shape.scaled(by: scale).translated(by: p1.position.distance))
             }
             p0 = p1
             p1 = p2
@@ -511,13 +511,13 @@ public extension Mesh {
         } else {
             var _p0p2: Direction! = p0p1
             shape = shape.rotated(by: rotationBetweenDirections(p0p1, shapeNormal))
-            shapes.append(shape.translated(by: Vector(p0.position)))
+            shapes.append(shape.translated(by: p0.position.distance))
             for i in 1 ..< count - 1 {
                 let p2 = points[i + 1]
                 addShape(p2, &_p0p2)
             }
             shape = shape.rotated(by: rotationBetweenDirections(p0p1, _p0p2))
-            shapes.append(shape.translated(by: Vector(points.last!.position)))
+            shapes.append(shape.translated(by: points.last!.position.distance))
         }
         return loft(shapes, faces: faces, material: material)
     }
@@ -627,9 +627,9 @@ public extension Mesh {
                 shape = shape.rotated(by: .pitch(.halfPi))
             }
             shape = shape.rotated(by: rotationBetweenDirections(line.direction, shape.faceNormal))
-            let shape0 = shape.translated(by: Vector(line.start))
+            let shape0 = shape.translated(by: line.start.distance)
             bounds.formUnion(shape0.bounds)
-            let shape1 = shape.translated(by: Vector(line.end))
+            let shape1 = shape.translated(by: line.end.distance)
             bounds.formUnion(shape1.bounds)
             loft(
                 unchecked: shape0, shape1,

--- a/Tests/CSGTests.swift
+++ b/Tests/CSGTests.swift
@@ -28,14 +28,14 @@ class CSGTests: XCTestCase {
 
     func testSubtractAdjacentBoxes() {
         let a = Mesh.cube()
-        let b = Mesh.cube().translated(by: Vector(1, 0, 0))
+        let b = Mesh.cube().translated(by: Distance(1, 0, 0))
         let c = a.subtract(b)
         XCTAssertEqual(c.bounds, a.bounds)
     }
 
     func testSubtractOverlappingBoxes() {
         let a = Mesh.cube()
-        let b = Mesh.cube().translated(by: Vector(0.5, 0, 0))
+        let b = Mesh.cube().translated(by: Distance(0.5, 0, 0))
         let c = a.subtract(b)
         XCTAssertEqual(c.bounds, Bounds(
             min: Position(-0.5, -0.5, -0.5),
@@ -61,14 +61,14 @@ class CSGTests: XCTestCase {
 
     func testXorAdjacentCubes() {
         let a = Mesh.cube()
-        let b = Mesh.cube().translated(by: Vector(1, 0, 0))
+        let b = Mesh.cube().translated(by: Distance(1, 0, 0))
         let c = a.xor(b)
         XCTAssertEqual(c.bounds, a.bounds.union(b.bounds))
     }
 
     func testXorOverlappingCubes() {
         let a = Mesh.cube()
-        let b = Mesh.cube().translated(by: Vector(0.5, 0, 0))
+        let b = Mesh.cube().translated(by: Distance(0.5, 0, 0))
         let c = a.xor(b)
         XCTAssertEqual(c.bounds, Bounds(
             min: Position(-0.5, -0.5, -0.5),
@@ -94,14 +94,14 @@ class CSGTests: XCTestCase {
 
     func testUnionOfAdjacentBoxes() {
         let a = Mesh.cube()
-        let b = Mesh.cube().translated(by: Vector(1, 0, 0))
+        let b = Mesh.cube().translated(by: Distance(1, 0, 0))
         let c = a.union(b)
         XCTAssertEqual(c.bounds, a.bounds.union(b.bounds))
     }
 
     func testUnionOfOverlappingBoxes() {
         let a = Mesh.cube()
-        let b = Mesh.cube().translated(by: Vector(0.5, 0, 0))
+        let b = Mesh.cube().translated(by: Distance(0.5, 0, 0))
         let c = a.union(b)
         XCTAssertEqual(c.bounds, Bounds(
             min: Position(-0.5, -0.5, -0.5),
@@ -127,7 +127,7 @@ class CSGTests: XCTestCase {
 
     func testIntersectionOfAdjacentBoxes() {
         let a = Mesh.cube()
-        let b = Mesh.cube().translated(by: Vector(1, 0, 0))
+        let b = Mesh.cube().translated(by: Distance(1, 0, 0))
         let c = a.intersect(b)
         // TODO: ideally this should probably be empty, but it's not clear
         // how to achieve that while also getting desired planar behavior
@@ -139,7 +139,7 @@ class CSGTests: XCTestCase {
 
     func testIntersectionOfOverlappingBoxes() {
         let a = Mesh.cube()
-        let b = Mesh.cube().translated(by: Vector(0.5, 0, 0))
+        let b = Mesh.cube().translated(by: Distance(0.5, 0, 0))
         let c = a.intersect(b)
         XCTAssertEqual(c.bounds, Bounds(
             min: Position(0, -0.5, -0.5),
@@ -165,14 +165,14 @@ class CSGTests: XCTestCase {
 
     func testSubtractAdjacentSquares() {
         let a = Mesh.fill(.square())
-        let b = Mesh.fill(.square()).translated(by: Vector(1, 0, 0))
+        let b = Mesh.fill(.square()).translated(by: Distance(1, 0, 0))
         let c = a.subtract(b)
         XCTAssertEqual(c.bounds, a.bounds)
     }
 
     func testSubtractOverlappingSquares() {
         let a = Mesh.fill(.square())
-        let b = Mesh.fill(.square()).translated(by: Vector(0.5, 0, 0))
+        let b = Mesh.fill(.square()).translated(by: Distance(0.5, 0, 0))
         let c = a.subtract(b)
         XCTAssertEqual(c.bounds, Bounds(
             min: Position(-0.5, -0.5, 0),
@@ -191,14 +191,14 @@ class CSGTests: XCTestCase {
 
     func testXorAdjacentSquares() {
         let a = Mesh.fill(.square())
-        let b = Mesh.fill(.square()).translated(by: Vector(1, 0, 0))
+        let b = Mesh.fill(.square()).translated(by: Distance(1, 0, 0))
         let c = a.xor(b)
         XCTAssertEqual(c.bounds, a.bounds.union(b.bounds))
     }
 
     func testXorOverlappingSquares() {
         let a = Mesh.fill(.square())
-        let b = Mesh.fill(.square()).translated(by: Vector(0.5, 0, 0))
+        let b = Mesh.fill(.square()).translated(by: Distance(0.5, 0, 0))
         let c = a.xor(b)
         XCTAssertEqual(c.bounds, Bounds(
             min: Position(-0.5, -0.5, 0),
@@ -217,14 +217,14 @@ class CSGTests: XCTestCase {
 
     func testUnionOfAdjacentSquares() {
         let a = Mesh.fill(.square())
-        let b = Mesh.fill(.square()).translated(by: Vector(1, 0, 0))
+        let b = Mesh.fill(.square()).translated(by: Distance(1, 0, 0))
         let c = a.union(b)
         XCTAssertEqual(c.bounds, a.bounds.union(b.bounds))
     }
 
     func testUnionOfOverlappingSquares() {
         let a = Mesh.fill(.square())
-        let b = Mesh.fill(.square()).translated(by: Vector(0.5, 0, 0))
+        let b = Mesh.fill(.square()).translated(by: Distance(0.5, 0, 0))
         let c = a.union(b)
         XCTAssertEqual(c.bounds, Bounds(
             min: Position(-0.5, -0.5, 0),
@@ -243,14 +243,14 @@ class CSGTests: XCTestCase {
 
     func testIntersectionOfAdjacentSquares() {
         let a = Mesh.fill(.square())
-        let b = Mesh.fill(.square()).translated(by: Vector(1, 0, 0))
+        let b = Mesh.fill(.square()).translated(by: Distance(1, 0, 0))
         let c = a.intersect(b)
         XCTAssert(c.polygons.isEmpty)
     }
 
     func testIntersectionOfOverlappingSquares() {
         let a = Mesh.fill(.square())
-        let b = Mesh.fill(.square()).translated(by: Vector(0.5, 0, 0))
+        let b = Mesh.fill(.square()).translated(by: Distance(0.5, 0, 0))
         let c = a.intersect(b)
         XCTAssertEqual(c.bounds, Bounds(
             min: Position(0, -0.5, 0),

--- a/Tests/PlaneTests.swift
+++ b/Tests/PlaneTests.swift
@@ -34,7 +34,7 @@ class PlaneTests: XCTestCase {
             Position(-0.707106781187, -0.707106781187, 1),
         ]
         let plane0 = Plane(points: points0)
-        let translation = Vector(1, 0)
+        let translation = Distance(1, 0)
         let points1 = points0.translated(by: translation)
         let plane1 = Plane(points: points1)
         let expected = plane0?.translated(by: translation)

--- a/Tests/ShapeTests.swift
+++ b/Tests/ShapeTests.swift
@@ -217,7 +217,7 @@ class ShapeTests: XCTestCase {
     func testLoftParallelEdges() {
         let shapes = [
             Path.square(),
-            Path.square().translated(by: Vector(0.0, 1.0, 0.0)),
+            Path.square().translated(by: Distance(0.0, 1.0, 0.0)),
         ]
 
         let loft = Mesh.loft(shapes)

--- a/Tests/TransformTests.swift
+++ b/Tests/TransformTests.swift
@@ -184,18 +184,18 @@ class TransformTests: XCTestCase {
     func testRotationMultipliedByTranslation() {
         let r = Rotation(roll: .zero, yaw: .pi / 4, pitch: .zero)
         let a = Transform(rotation: r)
-        let b = Transform(offset: Vector(1, 0, 0))
+        let b = Transform(offset: Distance(1, 0, 0))
         let c = a * b
-        XCTAssertEqual(c.offset, Vector(1, 0, 0))
+        XCTAssertEqual(c.offset, Distance(1, 0, 0))
         XCTAssertEqual(c.rotation, r)
     }
 
     func testTranslationMultipliedByRotation() {
         let r = Rotation(roll: .zero, yaw: .pi / 4, pitch: .zero)
-        let a = Transform(offset: Vector(1, 0, 0))
+        let a = Transform(offset: Distance(1, 0, 0))
         let b = Transform(rotation: r)
         let c = a * b
-        XCTAssertEqual(c.offset.quantized(), Vector(sqrt(2) / 2, 0, sqrt(2) / 2).quantized())
+        XCTAssertEqual(c.offset.quantized(), Distance(sqrt(2) / 2, 0, sqrt(2) / 2).quantized())
         XCTAssertEqual(c.offset, a.offset.rotated(by: r))
         XCTAssertEqual(c.rotation, r)
     }
@@ -219,10 +219,10 @@ class TransformTests: XCTestCase {
     }
 
     func testTranslationMultipliedByScale() {
-        let a = Transform(offset: Vector(1, 0, 0))
+        let a = Transform(offset: Distance(1, 0, 0))
         let b = Transform(scale: Vector(2, 1, 1))
         let c = a * b
-        XCTAssertEqual(c.offset, Vector(2, 0, 0))
+        XCTAssertEqual(c.offset, Distance(2, 0, 0))
         XCTAssertEqual(c.scale, Vector(2, 1, 1))
     }
 
@@ -231,7 +231,7 @@ class TransformTests: XCTestCase {
     func testTransformVector() {
         let v = Vector(1, 1, 1)
         let t = Transform(
-            offset: Vector(0.5, 0, 0),
+            offset: Distance(0.5, 0, 0),
             rotation: .roll(.halfPi),
             scale: Vector(1, 0.1, 0.1)
         )
@@ -244,8 +244,8 @@ class TransformTests: XCTestCase {
         let normal = Direction(0.5, 1, 0.5)
         let position = Vector(10, 5, -3)
         let plane = Plane(unchecked: normal, pointOnPlane: position)
-        let offset = Vector(12, 3, 4)
-        let expected = Plane(unchecked: normal, pointOnPlane: position + offset)
+        let offset = Distance(12, 3, 4)
+        let expected = Plane(unchecked: normal, pointOnPlane: position + Vector(offset))
         XCTAssert(plane.translated(by: offset).isEqual(to: expected))
     }
 
@@ -287,7 +287,7 @@ class TransformTests: XCTestCase {
         ])
         let plane = path.plane!
         let transform = Transform(
-            offset: Vector(-7, 3, 4.5),
+            offset: Distance(-7, 3, 4.5),
             rotation: Rotation(axis: Direction(11, 3, -1), angle: .radians(1.3)),
             scale: Vector(7, 2.0, 0.3)
         )
@@ -300,7 +300,7 @@ class TransformTests: XCTestCase {
     func testBoundsNotPreservedWhenMeshRotated() {
         let mesh = Mesh.cube()
         let transform = Transform(
-            offset: Vector(-7, 3, 4.5),
+            offset: Distance(-7, 3, 4.5),
             rotation: Rotation(axis: Direction(11, 3, -1), angle: .radians(1.3)),
             scale: Vector(7, 2.0, 0.3)
         )
@@ -310,7 +310,7 @@ class TransformTests: XCTestCase {
     func testBoundsPreservedWhenTransformingMeshWithoutRotation() {
         let mesh = Mesh.cube()
         let transform = Transform(
-            offset: Vector(-7, 3, 4.5),
+            offset: Distance(-7, 3, 4.5),
             rotation: .identity,
             scale: Vector(7, 2.0, 0.3)
         )

--- a/Tests/UtilityTests.swift
+++ b/Tests/UtilityTests.swift
@@ -21,7 +21,7 @@ class UtilityTests: XCTestCase {
             Position(-0.16346853203274558, 0, -0.06771088298918408),
         ]
         XCTAssertTrue(pointsAreConvex(vectors))
-        let offset = Vector(0, 0, 3)
+        let offset = Distance(0, 0, 3)
         let vertices = vectors.map { Vertex(Vector($0), .y).translated(by: offset) }
         XCTAssertTrue(verticesAreConvex(vertices))
     }


### PR DESCRIPTION
Overview of remaining refactoring steps from #37:

`line.origin` -> `Position` _[done]_
`lineSegment.start/end` -> `Position` _[done]_
`pathPoint.position` -> `Position` _[done]_
`transform.offset` -> `Distance` **[this PR]**
`transform.scale` -> `Distance` _[pending]_
`vertex.position` -> `Position` _[pending]_
`Plane(normal: Direction, pointOnPlane: Vector)` -> `pointOnPlane` should be `Position` _[pending]_