### PR TITLE
Vector semantics: transform scale (5/7)

### DIFF
--- a/Sources/CartesianComponentsRepresentable.swift
+++ b/Sources/CartesianComponentsRepresentable.swift
@@ -124,7 +124,7 @@ public extension CartesianComponentsRepresentable {
         self.init(x: vector.x, y: vector.y, z: vector.z)
     }
 
-    func scaled(by vn: Vector) -> Self {
+    func scaled(by vn: Distance) -> Self {
         Self(
             x: x * vn.x,
             y: y * vn.y,
@@ -138,6 +138,10 @@ public extension CartesianComponentsRepresentable {
             y: y * f,
             z: z * f
         )
+    }
+    
+    var absolute: Self {
+        Self(abs(x), abs(y), abs(z))
     }
 }
 

--- a/Sources/Euclid+SceneKit.swift
+++ b/Sources/Euclid+SceneKit.swift
@@ -515,7 +515,7 @@ public extension Transform {
         Transform(
             offset: Distance(scnNode.position),
             rotation: Rotation(scnNode.orientation),
-            scale: Vector(scnNode.scale)
+            scale: Distance(scnNode.scale)
         )
     }
 }

--- a/Sources/Shapes.swift
+++ b/Sources/Shapes.swift
@@ -238,7 +238,7 @@ public extension Mesh {
             )
             return Polygon(
                 unchecked: indexData.map { i in
-                    let pos = c + s.scaled(by: Vector(
+                    let pos = c + s.scaled(by: Distance(
                         i & 1 > 0 ? 0.5 : -0.5,
                         i & 2 > 0 ? 0.5 : -0.5,
                         i & 4 > 0 ? 0.5 : -0.5
@@ -489,11 +489,7 @@ public extension Mesh {
             } else {
                 let axis = p0p1.cross(p1p2)
                 let a = (1 / p0p1.dot(p0p2)) - 1
-                var scale = Vector(a * axis.cross(p0p2))
-                scale.x = abs(scale.x)
-                scale.y = abs(scale.y)
-                scale.z = abs(scale.z)
-                scale = scale + Vector(1, 1, 1)
+                let scale = (a * axis.cross(p0p2)).absolute + Distance(1, 1, 1)
                 shapes.append(shape.scaled(by: scale).translated(by: p1.position.distance))
             }
             p0 = p1

--- a/Tests/TransformTests.swift
+++ b/Tests/TransformTests.swift
@@ -203,27 +203,27 @@ class TransformTests: XCTestCase {
     func testRotationMultipliedByScale() {
         let r = Rotation(roll: .zero, yaw: .pi / 4, pitch: .zero)
         let a = Transform(rotation: r)
-        let b = Transform(scale: Vector(2, 1, 1))
+        let b = Transform(scale: Distance(2, 1, 1))
         let c = a * b
-        XCTAssertEqual(c.scale, Vector(2, 1, 1)) // scale is unaffected by rotation
+        XCTAssertEqual(c.scale, Distance(2, 1, 1)) // scale is unaffected by rotation
         XCTAssertEqual(c.rotation, r)
     }
 
     func testScaleMultipliedByRotation() {
         let r = Rotation(roll: .zero, yaw: .pi / 4, pitch: .zero)
-        let a = Transform(scale: Vector(2, 1, 1))
+        let a = Transform(scale: Distance(2, 1, 1))
         let b = Transform(rotation: r)
         let c = a * b
-        XCTAssertEqual(c.scale, Vector(2, 1, 1))
+        XCTAssertEqual(c.scale, Distance(2, 1, 1))
         XCTAssertEqual(c.rotation, r)
     }
 
     func testTranslationMultipliedByScale() {
         let a = Transform(offset: Distance(1, 0, 0))
-        let b = Transform(scale: Vector(2, 1, 1))
+        let b = Transform(scale: Distance(2, 1, 1))
         let c = a * b
         XCTAssertEqual(c.offset, Distance(2, 0, 0))
-        XCTAssertEqual(c.scale, Vector(2, 1, 1))
+        XCTAssertEqual(c.scale, Distance(2, 1, 1))
     }
 
     // MARK: Vector transform
@@ -233,7 +233,7 @@ class TransformTests: XCTestCase {
         let t = Transform(
             offset: Distance(0.5, 0, 0),
             rotation: .roll(.halfPi),
-            scale: Vector(1, 0.1, 0.1)
+            scale: Distance(1, 0.1, 0.1)
         )
         XCTAssertEqual(v.transformed(by: t).quantized(), Vector(0.6, -1.0, 0.1).quantized())
     }
@@ -264,8 +264,8 @@ class TransformTests: XCTestCase {
         let normal = Direction(0.5, 1, 0.5)
         let position = Vector(10, 5, -3)
         let plane = Plane(unchecked: normal, pointOnPlane: position)
-        let scale = Vector(0.5, 3.0, 0.1)
-        let expectedNormal = normal.scaled(by: Vector(1 / scale.x, 1 / scale.y, 1 / scale.z))
+        let scale = Distance(0.5, 3.0, 0.1)
+        let expectedNormal = normal.scaled(by: Distance(1 / scale.x, 1 / scale.y, 1 / scale.z))
         let expected = Plane(unchecked: expectedNormal, pointOnPlane: position.scaled(by: scale))
         XCTAssert(plane.scaled(by: scale).isEqual(to: expected))
     }
@@ -289,7 +289,7 @@ class TransformTests: XCTestCase {
         let transform = Transform(
             offset: Distance(-7, 3, 4.5),
             rotation: Rotation(axis: Direction(11, 3, -1), angle: .radians(1.3)),
-            scale: Vector(7, 2.0, 0.3)
+            scale: Distance(7, 2.0, 0.3)
         )
         let expected = path.transformed(by: transform).plane!
         XCTAssert(plane.transformed(by: transform).isEqual(to: expected))
@@ -302,7 +302,7 @@ class TransformTests: XCTestCase {
         let transform = Transform(
             offset: Distance(-7, 3, 4.5),
             rotation: Rotation(axis: Direction(11, 3, -1), angle: .radians(1.3)),
-            scale: Vector(7, 2.0, 0.3)
+            scale: Distance(7, 2.0, 0.3)
         )
         XCTAssertNil(mesh.transformed(by: transform).boundsIfSet)
     }
@@ -312,7 +312,7 @@ class TransformTests: XCTestCase {
         let transform = Transform(
             offset: Distance(-7, 3, 4.5),
             rotation: .identity,
-            scale: Vector(7, 2.0, 0.3)
+            scale: Distance(7, 2.0, 0.3)
         )
         XCTAssertNotNil(mesh.transformed(by: transform).boundsIfSet)
     }


### PR DESCRIPTION
Overview of remaining refactoring steps from #37:

`line.origin` -> `Position` _[done]_
`lineSegment.start/end` -> `Position` _[done]_
`pathPoint.position` -> `Position` _[done]_
`transform.offset` -> `Distance` _[done]_
`transform.scale` -> `Distance` **[this PR]**
`vertex.position` -> `Position` _[pending]_
`Plane(normal: Direction, pointOnPlane: Vector)` -> `pointOnPlane` should be `Position` _[pending]_