### PR TITLE
Vector semantics: vertex.position and Plane(normal:pointOnPlane) (6+7/7)

### DIFF
--- a/Sources/Bounds.swift
+++ b/Sources/Bounds.swift
@@ -86,8 +86,8 @@ public extension Bounds {
         var max = negativeInfinity
         for p in polygons {
             for v in p.vertices {
-                min = Position.min(min, Position(v.position))
-                max = Position.max(max, Position(v.position))
+                min = Position.min(min, v.position)
+                max = Position.max(max, v.position)
             }
         }
         self.min = min

--- a/Sources/CSG.swift
+++ b/Sources/CSG.swift
@@ -326,10 +326,10 @@ public extension Mesh {
             }
             let rect = Polygon(
                 unchecked: [
-                    Vertex(Vector(-radius, radius, 0), -normal, .zero),
-                    Vertex(Vector(radius, radius, 0), -normal, Vector(1, 0, 0)),
-                    Vertex(Vector(radius, -radius, 0), -normal, Vector(1, 1, 0)),
-                    Vertex(Vector(-radius, -radius, 0), -normal, Vector(0, 1, 0)),
+                    Vertex(Position(-radius, radius, 0), -normal, .zero),
+                    Vertex(Position(radius, radius, 0), -normal, Vector(1, 0, 0)),
+                    Vertex(Position(radius, -radius, 0), -normal, Vector(1, 1, 0)),
+                    Vertex(Position(-radius, -radius, 0), -normal, Vector(0, 1, 0)),
                 ],
                 normal: -normal,
                 isConvex: true,

--- a/Sources/Euclid+SceneKit.swift
+++ b/Sources/Euclid+SceneKit.swift
@@ -339,7 +339,7 @@ public extension SCNGeometry {
     /// Creates line-segment SCNGeometry representing the vertex normals of a Mesh
     convenience init(normals mesh: Mesh, scale: Double = 1) {
         self.init(Set(mesh.polygons.flatMap { $0.vertices }.compactMap {
-            LineSegment(Position($0.position), Position($0.position) + $0.normal * scale)
+            LineSegment($0.position, $0.position + $0.normal * scale)
         }))
     }
 
@@ -347,7 +347,7 @@ public extension SCNGeometry {
     convenience init(_ path: Path) {
         var indexData = Data()
         var vertexData = Data()
-        var indicesByPoint = [Vector: UInt32]()
+        var indicesByPoint = [Position: UInt32]()
         for path in path.subpaths {
             for vertex in path.edgeVertices {
                 let origin = vertex.position
@@ -476,8 +476,8 @@ private extension Data {
         return Double(float)
     }
 
-    func vector(at index: Int) -> Vector {
-        Vector(
+    func position(at index: Int) -> Position {
+        Position(
             float(at: index),
             float(at: index + 4),
             float(at: index + 8)
@@ -562,7 +562,7 @@ public extension Mesh {
         for source in scnGeometry.sources {
             let count = source.vectorCount
             if vertices.isEmpty {
-                vertices = Array(repeating: Vertex(.zero, .zero), count: count)
+                vertices = Array(repeating: Vertex(.origin, .zero), count: count)
             } else if vertices.count != source.vectorCount {
                 return nil
             }
@@ -572,12 +572,12 @@ public extension Mesh {
             switch source.semantic {
             case .vertex:
                 for i in 0 ..< count {
-                    vertices[i].position = data.vector(at: offset)
+                    vertices[i].position = data.position(at: offset)
                     offset += stride
                 }
             case .normal:
                 for i in 0 ..< count {
-                    vertices[i].normal = Direction(data.vector(at: offset))
+                    vertices[i].normal = data.position(at: offset).distance.direction
                     offset += stride
                 }
             case .texcoord:

--- a/Sources/Paths.swift
+++ b/Sources/Paths.swift
@@ -234,10 +234,9 @@ public extension Path {
 
     /// Create a path from a polygon
     init(polygon: Polygon) {
-        let hasTexcoords = polygon.hasTexcoords
         self.init(
             unchecked: polygon.vertices.map {
-                .point(Position($0.position), texcoord: hasTexcoords ? $0.texcoord : nil)
+                .point($0.position, texcoord: polygon.hasTextureCoordinates ? $0.texcoord : nil)
             },
             plane: polygon.plane,
             subpathIndices: nil
@@ -311,7 +310,7 @@ public extension Path {
                 [p0.position, p1.position, points[i + 1].position],
                 convex: true
             )
-            vertices.append(Vertex(unchecked: Vector(p1.position), normal, texcoord ?? .zero))
+            vertices.append(Vertex(unchecked: p1.position, normal, texcoord ?? .zero))
             p0 = p1
         }
         guard !verticesAreDegenerate(vertices) else {
@@ -324,7 +323,7 @@ public extension Path {
         var max = Vector(-.infinity, -.infinity)
         let flatteningPlane = FlatteningPlane(normal: faceNormal)
         vertices = vertices.map {
-            let uv = flatteningPlane.flattenPoint(Position($0.position))
+            let uv = flatteningPlane.flattenPoint($0.position)
             min.x = Swift.min(min.x, uv.x)
             min.y = Swift.min(min.y, uv.y)
             max.x = Swift.max(max.x, uv.x)
@@ -411,12 +410,12 @@ public extension Path {
                 v += abs(p1p2.y) / totalLength
             }
             if p1.isCurved {
-                let v = Vertex(Vector(p1.position), Direction.mean(n0, n1), uv)
+                let v = Vertex(p1.position, Direction.mean(n0, n1), uv)
                 vertices.append(v)
                 vertices.append(v)
             } else {
-                vertices.append(Vertex(Vector(p1.position), n0, uv))
-                vertices.append(Vertex(Vector(p1.position), n1, uv))
+                vertices.append(Vertex(p1.position, n0, uv))
+                vertices.append(Vertex(p1.position, n1, uv))
             }
         }
         var first = vertices.removeFirst()

--- a/Sources/Plane.swift
+++ b/Sources/Plane.swift
@@ -80,7 +80,7 @@ public extension Plane {
     static let xy = Plane(normal: .z, w: 0)
 
     /// Creates a plane from a point and surface normal
-    init?(normal: Direction, pointOnPlane: Vector) {
+    init?(normal: Direction, pointOnPlane: Position) {
         guard normal.norm > epsilon else {
             return nil
         }
@@ -169,8 +169,8 @@ public extension Plane {
 }
 
 internal extension Plane {
-    init(unchecked normal: Direction, pointOnPlane: Vector) {
-        self.init(normal: normal, w: Distance(pointOnPlane).dot(normal))
+    init(unchecked normal: Direction, pointOnPlane: Position) {
+        self.init(normal: normal, w: pointOnPlane.distance.dot(normal))
     }
 
     init?(points: [Position], convex: Bool?) {
@@ -187,7 +187,7 @@ internal extension Plane {
     init(unchecked points: [Position], convex: Bool?) {
         assert(!pointsAreDegenerate(points))
         let normal = faceNormalForPolygonPoints(points, convex: convex)
-        self.init(unchecked: normal, pointOnPlane: Vector(points[0]))
+        self.init(unchecked: normal, pointOnPlane: points[0])
     }
 
     // Approximate equality

--- a/Sources/Position.swift
+++ b/Sources/Position.swift
@@ -32,6 +32,10 @@ public extension Position {
     var distance: Distance {
         Distance(x, y, z)
     }
+    
+    init(_ distance: Distance) {
+        self.init(x: distance.x, y: distance.y, z: distance.z)
+    }
 }
 
 public extension Position {

--- a/Sources/Shapes.swift
+++ b/Sources/Shapes.swift
@@ -216,8 +216,8 @@ public extension Mesh {
 
     /// Construct an axis-aligned cuboid mesh
     static func cube(
-        center c: Vector = .init(0, 0, 0),
-        size s: Vector,
+        center c: Position = .init(0, 0, 0),
+        size s: Distance,
         faces: Faces = .default,
         material: Material? = nil
     ) -> Mesh {
@@ -256,7 +256,7 @@ public extension Mesh {
             )
         }
         let halfSize = s / 2
-        let bounds = Bounds(min: Position(c - halfSize), max: Position(c + halfSize))
+        let bounds = Bounds(min: c - halfSize, max: c + halfSize)
         switch faces {
         case .front, .default:
             return Mesh(
@@ -280,12 +280,12 @@ public extension Mesh {
     }
 
     static func cube(
-        center c: Vector = .init(0, 0, 0),
+        center c: Position = .init(0, 0, 0),
         size s: Double = 1,
         faces: Faces = .default,
         material: Material? = nil
     ) -> Mesh {
-        cube(center: c, size: Vector(s, s, s), faces: faces, material: material)
+        cube(center: c, size: Distance(s, s, s), faces: faces, material: material)
     }
 
     /// Construct a sphere mesh
@@ -742,13 +742,13 @@ private extension Mesh {
                         )
                         let v2 = Vertex(
                             unchecked:
-                            Vector(cos0 * v1.position.x, v1.position.y, sin0 * -v1.position.x),
+                            Position(cos0 * v1.position.x, v1.position.y, sin0 * -v1.position.x),
                             Direction(cos0 * v1.normal.x, v1.normal.y, sin0 * -v1.normal.x),
                             Vector(v1.texcoord.x + t0, v1.texcoord.y, 0)
                         )
                         let v3 = Vertex(
                             unchecked:
-                            Vector(cos1 * v1.position.x, v1.position.y, sin1 * -v1.position.x),
+                            Position(cos1 * v1.position.x, v1.position.y, sin1 * -v1.position.x),
                             Direction(cos1 * v1.normal.x, v1.normal.y, sin1 * -v1.normal.x),
                             Vector(v1.texcoord.x + t1, v1.texcoord.y, 0)
                         )
@@ -768,13 +768,13 @@ private extension Mesh {
                     )
                     let v2 = Vertex(
                         unchecked:
-                        Vector(cos1 * v0.position.x, v0.position.y, sin1 * -v0.position.x),
+                        Position(cos1 * v0.position.x, v0.position.y, sin1 * -v0.position.x),
                         Direction(cos1 * v0.normal.x, v0.normal.y, sin1 * -v0.normal.x),
                         Vector(v0.texcoord.x + t1, v0.texcoord.y, 0)
                     )
                     let v3 = Vertex(
                         unchecked:
-                        Vector(cos0 * v0.position.x, v0.position.y, sin0 * -v0.position.x),
+                        Position(cos0 * v0.position.x, v0.position.y, sin0 * -v0.position.x),
                         Direction(cos0 * v0.normal.x, v0.normal.y, sin0 * -v0.normal.x),
                         Vector(v0.texcoord.x + t0, v0.texcoord.y, 0)
                     )
@@ -788,25 +788,25 @@ private extension Mesh {
                     // quad face
                     let v2 = Vertex(
                         unchecked:
-                        Vector(cos1 * v0.position.x, v0.position.y, sin1 * -v0.position.x),
+                        Position(cos1 * v0.position.x, v0.position.y, sin1 * -v0.position.x),
                         Direction(cos1 * v0.normal.x, v0.normal.y, sin1 * -v0.normal.x),
                         Vector(v0.texcoord.x + t1, v0.texcoord.y, 0)
                     )
                     let v3 = Vertex(
                         unchecked:
-                        Vector(cos0 * v0.position.x, v0.position.y, sin0 * -v0.position.x),
+                        Position(cos0 * v0.position.x, v0.position.y, sin0 * -v0.position.x),
                         Direction(cos0 * v0.normal.x, v0.normal.y, sin0 * -v0.normal.x),
                         Vector(v0.texcoord.x + t0, v0.texcoord.y, 0)
                     )
                     let v4 = Vertex(
                         unchecked:
-                        Vector(cos0 * v1.position.x, v1.position.y, sin0 * -v1.position.x),
+                        Position(cos0 * v1.position.x, v1.position.y, sin0 * -v1.position.x),
                         Direction(cos0 * v1.normal.x, v1.normal.y, sin0 * -v1.normal.x),
                         Vector(v1.texcoord.x + t0, v1.texcoord.y, 0)
                     )
                     let v5 = Vertex(
                         unchecked:
-                        Vector(cos1 * v1.position.x, v1.position.y, sin1 * -v1.position.x),
+                        Position(cos1 * v1.position.x, v1.position.y, sin1 * -v1.position.x),
                         Direction(cos1 * v1.normal.x, v1.normal.y, sin1 * -v1.normal.x),
                         Vector(v1.texcoord.x + t1, v1.texcoord.y, 0)
                     )

--- a/Sources/Transforms.swift
+++ b/Sources/Transforms.swift
@@ -276,7 +276,7 @@ internal extension Collection where Element == Polygon {
 
 public extension Vertex {
     func translated(by v: Distance) -> Vertex {
-        Vertex(position + Vector(v), normal, texcoord)
+        Vertex(position + v, normal, texcoord)
     }
 
     @_disfavoredOverload
@@ -298,7 +298,7 @@ public extension Vertex {
     }
 
     func scaled(by f: Double) -> Vertex {
-        Vertex(position * f, normal, texcoord)
+        Vertex(position.scaled(by: f), normal, texcoord)
     }
 
     func transformed(by t: Transform) -> Vertex {
@@ -537,7 +537,7 @@ public extension Path {
 
 public extension Plane {
     func translated(by v: Distance) -> Plane {
-        Plane(unchecked: normal, pointOnPlane: Vector(v + w * normal))
+        Plane(unchecked: normal, pointOnPlane: Position(v + w * normal))
     }
 
     @_disfavoredOverload
@@ -551,8 +551,8 @@ public extension Plane {
 
     func scaled(by v: Distance) -> Plane {
         let vn = Distance(1 / v.x, 1 / v.y, 1 / v.z)
-        let p = (w * normal).scaled(by: v)
-        return Plane(unchecked: normal.scaled(by: vn), pointOnPlane: Vector(p))
+        let p = Position((w * normal).scaled(by: v))
+        return Plane(unchecked: normal.scaled(by: vn), pointOnPlane: p)
     }
 
     func scaled(by f: Double) -> Plane {

--- a/Sources/Utilities.swift
+++ b/Sources/Utilities.swift
@@ -72,7 +72,7 @@ func verticesAreDegenerate(_ vertices: [Vertex]) -> Bool {
     guard vertices.count > 2 else {
         return true
     }
-    let positions = vertices.map { Position($0.position) }
+    let positions = vertices.map { $0.position }
     return pointsAreDegenerate(positions) || pointsAreSelfIntersecting(positions)
 }
 
@@ -80,7 +80,7 @@ func verticesAreConvex(_ vertices: [Vertex]) -> Bool {
     guard vertices.count > 3 else {
         return vertices.count > 2
     }
-    return pointsAreConvex(vertices.map { Position($0.position) })
+    return pointsAreConvex(vertices.map { $0.position })
 }
 
 func verticesAreCoplanar(_ vertices: [Vertex]) -> Bool {
@@ -122,7 +122,7 @@ func triangulateVertices(
         ))
         return true
     }
-    let positions = vertices.map { Position($0.position) }
+    let positions = vertices.map { $0.position }
     if isConvex ?? pointsAreConvex(positions) {
         let v0 = vertices[0]
         var v1 = vertices[1]
@@ -140,7 +140,7 @@ func triangulateVertices(
         normal: plane?.normal ??
             faceNormalForPolygonPoints(positions, convex: false)
     )
-    let flattenedPoints = vertices.map { flatteningPlane.flattenPoint(Position($0.position)) }
+    let flattenedPoints = vertices.map { flatteningPlane.flattenPoint($0.position) }
     let isClockwise = flattenedPointsAreClockwise(flattenedPoints)
     if !isClockwise {
         guard flattenedPointsAreClockwise(flattenedPoints.reversed()) else {
@@ -171,7 +171,7 @@ func triangulateVertices(
         let p2 = vertices[(i + 1) % vertices.count]
         // check for colinear points
         let p0p1 = p0.position - p1.position, p2p1 = p2.position - p1.position
-        if p0p1.cross(p2p1).length < epsilon {
+        if p0p1.cross(p2p1).norm < epsilon {
             // vertices are colinear, so we can't form a triangle
             if p0p1.dot(p2p1) > 0 {
                 // center point makes path degenerate - remove it
@@ -356,7 +356,7 @@ func faceNormalForPolygonPoints(_ points: [Position], convex: Bool?) -> Directio
     }
 }
 
-func pointsAreCoplanar(_ points: [Vector]) -> Bool {
+func pointsAreCoplanar(_ points: [Position]) -> Bool {
     if points.count < 4 {
         return true
     }
@@ -364,12 +364,12 @@ func pointsAreCoplanar(_ points: [Vector]) -> Bool {
     let ab = b - points[0]
     let bc = points[2] - b
     let normal = ab.cross(bc)
-    let length = normal.length
+    let length = normal.norm
     if length < epsilon {
         return false
     }
-    let plane = Plane(unchecked: Direction(normal), pointOnPlane: b)
-    for p in points[3...] where !plane.containsPoint(Position(p)) {
+    let plane = Plane(unchecked: normal.direction, pointOnPlane: b)
+    for p in points[3...] where !plane.containsPoint(p) {
         return false
     }
     return true

--- a/Sources/Vertex.swift
+++ b/Sources/Vertex.swift
@@ -31,7 +31,7 @@
 
 /// A polygon vertex
 public struct Vertex: Hashable {
-    public var position: Vector {
+    public var position: Position {
         didSet { position = position.quantized() }
     }
 
@@ -40,7 +40,7 @@ public struct Vertex: Hashable {
     public var texcoord: Vector
 
     public init(
-        _ position: Vector,
+        _ position: Position,
         _ normal: Direction? = nil,
         _ texcoord: Vector? = nil
     ) {
@@ -54,23 +54,23 @@ public struct Vertex: Hashable {
     public init?(_ values: [Double]) {
         switch values.count {
         case 2:
-            self.init(Vector(values[0], values[1]))
+            self.init(Position(values[0], values[1]))
         case 3:
-            self.init(Vector(values[0], values[1], values[2]))
+            self.init(Position(values[0], values[1], values[2]))
         case 6:
             self.init(
-                Vector(values[0], values[1], values[2]),
+                Position(values[0], values[1], values[2]),
                 Direction(x: values[3], y: values[4], z: values[5])
             )
         case 8:
             self.init(
-                Vector(values[0], values[1], values[2]),
+                Position(values[0], values[1], values[2]),
                 Direction(x: values[3], y: values[4], z: values[5]),
                 Vector(values[6], values[7])
             )
         case 9:
             self.init(
-                Vector(values[0], values[1], values[2]),
+                Position(values[0], values[1], values[2]),
                 Direction(x: values[3], y: values[4], z: values[5]),
                 Vector(values[6], values[7], values[8])
             )
@@ -88,7 +88,7 @@ extension Vertex: Codable {
     public init(from decoder: Decoder) throws {
         if let container = try? decoder.container(keyedBy: CodingKeys.self) {
             try self.init(
-                container.decode(Vector.self, forKey: .position),
+                container.decode(Position.self, forKey: .position),
                 container.decodeIfPresent(Direction.self, forKey: .normal),
                 container.decodeIfPresent(Vector.self, forKey: .texcoord)
             )
@@ -135,7 +135,7 @@ public extension Vertex {
 }
 
 internal extension Vertex {
-    init(unchecked position: Vector, _ normal: Direction, _ texcoord: Vector = .zero) {
+    init(unchecked position: Position, _ normal: Direction, _ texcoord: Vector = .zero) {
         self.position = position.quantized()
         self.normal = normal
         self.texcoord = texcoord

--- a/Tests/CodingTests.swift
+++ b/Tests/CodingTests.swift
@@ -161,7 +161,7 @@ class CodingTests: XCTestCase {
             "normal": [1, 0, 0],
             "texcoord": [0, 1]
         }
-        """), Vertex(Vector(1, 2, 2), .x, Vector(0, 1)))
+        """), Vertex(Position(1, 2, 2), .x, Vector(0, 1)))
     }
 
     func testDecodingVertexWithTexcoord3D() {
@@ -171,33 +171,33 @@ class CodingTests: XCTestCase {
             "normal": [1, 0, 0],
             "texcoord": [0, 1, 2]
         }
-        """), Vertex(Vector(1, 2, 2), .x, Vector(0, 1, 2)))
+        """), Vertex(Position(1, 2, 2), .x, Vector(0, 1, 2)))
     }
 
     func testDecodingFlattenedVertex() {
         XCTAssertEqual(
             try decode("[1, 2, 2, 1, 0, 0, 0, 1]"),
-            Vertex(Vector(1, 2, 2), .x, Vector(0, 1))
+            Vertex(Position(1, 2, 2), .x, Vector(0, 1))
         )
     }
 
     func testDecodingFlattenedVertexWithTexcoord3D() {
         XCTAssertEqual(
             try decode("[1, 2, 2, 1, 0, 0, 0, 1, 2]"),
-            Vertex(Vector(1, 2, 2), .x, Vector(0, 1, 2))
+            Vertex(Position(1, 2, 2), .x, Vector(0, 1, 2))
         )
     }
 
     func testEncodingVertex() {
         XCTAssertEqual(
-            try encode(Vertex(Vector(1, 2, 2), .x, Vector(0, 1))),
+            try encode(Vertex(Position(1, 2, 2), .x, Vector(0, 1))),
             "[1,2,2,1,0,0,0,1]"
         )
     }
 
     func testEncodingVertexWithTexcoord3D() {
         XCTAssertEqual(
-            try encode(Vertex(Vector(1, 2, 2), .x, Vector(0, 1, 2))),
+            try encode(Vertex(Position(1, 2, 2), .x, Vector(0, 1, 2))),
             "[1,2,2,1,0,0,0,1,2]"
         )
     }
@@ -208,26 +208,26 @@ class CodingTests: XCTestCase {
             "position": [1, 2, 2],
             "normal": [1, 0, 0]
         }
-        """), Vertex(Vector(1, 2, 2), .x, .zero))
+        """), Vertex(Position(1, 2, 2), .x, .zero))
     }
 
     func testDecodingFlattenedVertexWithoutTexcoord() {
         XCTAssertEqual(
             try decode("[1, 2, 2, 1, 0, 0]"),
-            Vertex(Vector(1, 2, 2), .x)
+            Vertex(Position(1, 2, 2), .x)
         )
     }
 
     func testEncodingVertexWithoutTexcoord() {
         XCTAssertEqual(
-            try encode(Vertex(Vector(1, 2, 2), .x)),
+            try encode(Vertex(Position(1, 2, 2), .x)),
             "[1,2,2,1,0,0]"
         )
     }
 
     func testEncodingVertex2DWithoutTexcoord() {
         XCTAssertEqual(
-            try encode(Vertex(Vector(1, 2), .x)),
+            try encode(Vertex(Position(1, 2), .x)),
             "[1,2,0,1,0,0]"
         )
     }
@@ -238,7 +238,7 @@ class CodingTests: XCTestCase {
             "position": [1, 2, 2],
             "texcoord": [1, 0]
         }
-        """), Vertex(Vector(1, 2, 2), nil, Vector(1, 0)))
+        """), Vertex(Position(1, 2, 2), nil, Vector(1, 0)))
     }
 
     func testDecodingVertexWithoutNormalWithTexcoord3D() {
@@ -247,11 +247,11 @@ class CodingTests: XCTestCase {
             "position": [1, 2, 2],
             "texcoord": [1, 0, 2]
         }
-        """), Vertex(Vector(1, 2, 2), nil, Vector(1, 0, 2)))
+        """), Vertex(Position(1, 2, 2), nil, Vector(1, 0, 2)))
     }
 
     func testDecodingFlattenedVertexWithoutNormal() {
-        XCTAssertEqual(try decode("[1, 2, 2]"), Vertex(Vector(1, 2, 2)))
+        XCTAssertEqual(try decode("[1, 2, 2]"), Vertex(Position(1, 2, 2)))
     }
 
     func testDecodingVertexWithInvalidNormal() {
@@ -261,7 +261,7 @@ class CodingTests: XCTestCase {
             "normal": [1, 2, 2]
         }
         """), Vertex(
-            Vector(1, 2, 2),
+            Position(1, 2, 2),
             Direction(0.3333333333333333, 0.6666666666666666, 0.6666666666666666),
             .zero
         ))
@@ -269,20 +269,20 @@ class CodingTests: XCTestCase {
 
     func testEncodingVertexWithoutNormal() {
         XCTAssertEqual(
-            try encode(Vertex(Vector(1, 2, 2))),
+            try encode(Vertex(Position(1, 2, 2))),
             "[1,2,2]"
         )
     }
 
     func testEncodingVertex2DWithoutNormal() {
         XCTAssertEqual(
-            try encode(Vertex(Vector(1, 2))),
+            try encode(Vertex(Position(1, 2))),
             "[1,2]"
         )
     }
 
     func testEncodeDecodeVertexWithTexcoordButWithoutNormal() throws {
-        let vertex = Vertex(.zero, .zero, Vector(0, 1))
+        let vertex = Vertex(.origin, .zero, Vector(0, 1))
         let encoded = try encode(vertex)
         XCTAssertEqual(encoded, "[0,0,0,0,0,0,0,1]")
         XCTAssertEqual(try decode(encoded), vertex)
@@ -407,9 +407,9 @@ class CodingTests: XCTestCase {
             ]
         }
         """), Polygon([
-            Vertex(Vector(0, 0), .z, Vector(0, 1)),
-            Vertex(Vector(1, 0), .z, Vector(1, 1)),
-            Vertex(Vector(1, 1), .z, Vector(1, 0)),
+            Vertex(Position(0, 0), .z, Vector(0, 1)),
+            Vertex(Position(1, 0), .z, Vector(1, 1)),
+            Vertex(Position(1, 1), .z, Vector(1, 0)),
         ]))
     }
 
@@ -430,9 +430,9 @@ class CodingTests: XCTestCase {
             },
         ]
         """), Polygon([
-            Vertex(Vector(0, 0), .z),
-            Vertex(Vector(1, 0), .z),
-            Vertex(Vector(1, 1), .z),
+            Vertex(Position(0, 0), .z),
+            Vertex(Position(1, 0), .z),
+            Vertex(Position(1, 1), .z),
         ]))
     }
 
@@ -444,9 +444,9 @@ class CodingTests: XCTestCase {
             [1, 1, 0, 0, 0, 1],
         ]
         """), Polygon([
-            Vertex(Vector(0, 0), .z),
-            Vertex(Vector(1, 0), .z),
-            Vertex(Vector(1, 1), .z),
+            Vertex(Position(0, 0), .z),
+            Vertex(Position(1, 0), .z),
+            Vertex(Position(1, 1), .z),
         ]))
     }
 
@@ -473,9 +473,9 @@ class CodingTests: XCTestCase {
             """),
             Polygon(
                 unchecked: [
-                    Vertex(Vector(0, 0), .z),
-                    Vertex(Vector(1, 0), .z),
-                    Vertex(Vector(1, 1), .z),
+                    Vertex(Position(0, 0), .z),
+                    Vertex(Position(1, 0), .z),
+                    Vertex(Position(1, 1), .z),
                 ],
                 plane: Plane(normal: .z, w: 0)
             )
@@ -501,9 +501,9 @@ class CodingTests: XCTestCase {
             ]
         }
         """), Polygon([
-            Vertex(Vector(0, 0), .z, Vector(0, 1)),
-            Vertex(Vector(1, 0), .z, Vector(1, 1)),
-            Vertex(Vector(1, 1), .z, Vector(1, 0)),
+            Vertex(Position(0, 0), .z, Vector(0, 1)),
+            Vertex(Position(1, 0), .z, Vector(1, 1)),
+            Vertex(Position(1, 1), .z, Vector(1, 0)),
         ]))
     }
 
@@ -515,18 +515,18 @@ class CodingTests: XCTestCase {
             [1, 1],
         ]
         """), Polygon([
-            Vertex(Vector(0, 0), .z),
-            Vertex(Vector(1, 0), .z),
-            Vertex(Vector(1, 1), .z),
+            Vertex(Position(0, 0), .z),
+            Vertex(Position(1, 0), .z),
+            Vertex(Position(1, 1), .z),
         ]))
     }
 
     func testEncodingPolygonWithTexcoordsWhereVertexNormalsMatchPlane() throws {
         let polygon = Polygon(
             unchecked: [
-                Vertex(Vector(0, 0, 1), .z, Vector(0, 1)),
-                Vertex(Vector(1, 0, 1), .z, Vector(1, 1)),
-                Vertex(Vector(1, 1, 1), .z, Vector(1, 0)),
+                Vertex(Position(0, 0, 1), .z, Vector(0, 1)),
+                Vertex(Position(1, 0, 1), .z, Vector(1, 1)),
+                Vertex(Position(1, 1, 1), .z, Vector(1, 0)),
             ],
             plane: Plane(normal: .z, w: 1)
         )
@@ -538,9 +538,9 @@ class CodingTests: XCTestCase {
     func testEncodingPolygonWithoutTexcoordsWhereVertexNormalsMatchPlane() throws {
         let polygon = Polygon(
             unchecked: [
-                Vertex(Vector(0, 0, 1), .z),
-                Vertex(Vector(1, 0, 1), .z),
-                Vertex(Vector(1, 1, 1), .z),
+                Vertex(Position(0, 0, 1), .z),
+                Vertex(Position(1, 0, 1), .z),
+                Vertex(Position(1, 1, 1), .z),
             ],
             plane: Plane(normal: .z, w: 1)
         )
@@ -552,9 +552,9 @@ class CodingTests: XCTestCase {
     func testEncodingPolygonWhereVertexNormalsDoNotMatchPlane() throws {
         let polygon = Polygon(
             unchecked: [
-                Vertex(Vector(0, 0, 1), .z),
-                Vertex(Vector(1, 0, 1), .z),
-                Vertex(Vector(1, 1, 1), .z),
+                Vertex(Position(0, 0, 1), .z),
+                Vertex(Position(1, 0, 1), .z),
+                Vertex(Position(1, 1, 1), .z),
             ],
             plane: Plane(normal: -.z, w: 1)
         )
@@ -671,9 +671,9 @@ class CodingTests: XCTestCase {
             Mesh([
                 Polygon(
                     unchecked: [
-                        Vertex(Vector(0, 0), .z),
-                        Vertex(Vector(1, 0), .z),
-                        Vertex(Vector(1, 1), .z),
+                        Vertex(Position(0, 0), .z),
+                        Vertex(Position(1, 0), .z),
+                        Vertex(Position(1, 1), .z),
                     ],
                     plane: Plane(normal: .z, w: 0)
                 ),

--- a/Tests/PathTests.swift
+++ b/Tests/PathTests.swift
@@ -283,14 +283,14 @@ class PathTests: XCTestCase {
         XCTAssertEqual(vertices.count, 8)
         guard vertices.count >= 8 else { return }
         // positions
-        XCTAssertEqual(vertices[0].position, Vector(-1, 1))
-        XCTAssertEqual(vertices[1].position, Vector(-1, -1))
-        XCTAssertEqual(vertices[2].position, Vector(-1, -1))
-        XCTAssertEqual(vertices[3].position, Vector(1, -1))
-        XCTAssertEqual(vertices[4].position, Vector(1, -1))
-        XCTAssertEqual(vertices[5].position, Vector(1, 1))
-        XCTAssertEqual(vertices[6].position, Vector(1, 1))
-        XCTAssertEqual(vertices[7].position, Vector(-1, 1))
+        XCTAssertEqual(vertices[0].position, Position(-1, 1))
+        XCTAssertEqual(vertices[1].position, Position(-1, -1))
+        XCTAssertEqual(vertices[2].position, Position(-1, -1))
+        XCTAssertEqual(vertices[3].position, Position(1, -1))
+        XCTAssertEqual(vertices[4].position, Position(1, -1))
+        XCTAssertEqual(vertices[5].position, Position(1, 1))
+        XCTAssertEqual(vertices[6].position, Position(1, 1))
+        XCTAssertEqual(vertices[7].position, Position(-1, 1))
         // texture coords
         XCTAssertEqual(vertices[0].texcoord, Vector(0, 0))
         XCTAssertEqual(vertices[1].texcoord, Vector(0, 0.25))
@@ -322,12 +322,12 @@ class PathTests: XCTestCase {
         XCTAssertEqual(vertices.count, 6)
         guard vertices.count >= 6 else { return }
         // positions
-        XCTAssertEqual(vertices[0].position, Vector(0, 1))
-        XCTAssertEqual(vertices[1].position, Vector(-1, 1))
-        XCTAssertEqual(vertices[2].position, Vector(-1, 1))
-        XCTAssertEqual(vertices[3].position, Vector(-1, -1))
-        XCTAssertEqual(vertices[4].position, Vector(-1, -1))
-        XCTAssertEqual(vertices[5].position, Vector(0, -1))
+        XCTAssertEqual(vertices[0].position, Position(0, 1))
+        XCTAssertEqual(vertices[1].position, Position(-1, 1))
+        XCTAssertEqual(vertices[2].position, Position(-1, 1))
+        XCTAssertEqual(vertices[3].position, Position(-1, -1))
+        XCTAssertEqual(vertices[4].position, Position(-1, -1))
+        XCTAssertEqual(vertices[5].position, Position(0, -1))
         // texture coords
         XCTAssertEqual(vertices[0].texcoord, Vector(0, 0))
         XCTAssertEqual(vertices[1].texcoord, Vector(0, 0.25))
@@ -357,12 +357,12 @@ class PathTests: XCTestCase {
         XCTAssertEqual(vertices.count, 6)
         guard vertices.count >= 6 else { return }
         // positions
-        XCTAssertEqual(vertices[0].position, Vector(0, 1))
-        XCTAssertEqual(vertices[1].position, Vector(-1, 1))
-        XCTAssertEqual(vertices[2].position, Vector(-1, 1))
-        XCTAssertEqual(vertices[3].position, Vector(-1, -1))
-        XCTAssertEqual(vertices[4].position, Vector(-1, -1))
-        XCTAssertEqual(vertices[5].position, Vector(0, -1))
+        XCTAssertEqual(vertices[0].position, Position(0, 1))
+        XCTAssertEqual(vertices[1].position, Position(-1, 1))
+        XCTAssertEqual(vertices[2].position, Position(-1, 1))
+        XCTAssertEqual(vertices[3].position, Position(-1, -1))
+        XCTAssertEqual(vertices[4].position, Position(-1, -1))
+        XCTAssertEqual(vertices[5].position, Position(0, -1))
         // texture coords
         XCTAssertEqual(vertices[0].texcoord, Vector(0, 0))
         XCTAssertEqual(vertices[1].texcoord, Vector(0, 0.25))
@@ -385,14 +385,14 @@ class PathTests: XCTestCase {
         XCTAssertEqual(vertices.count, 8)
         guard vertices.count >= 8 else { return }
         // positions
-        XCTAssertEqual(vertices[0].position, Vector(0, 1))
-        XCTAssertEqual(vertices[1].position, Vector(-1, 0))
-        XCTAssertEqual(vertices[2].position, Vector(-1, 0))
-        XCTAssertEqual(vertices[3].position, Vector(0, -1))
-        XCTAssertEqual(vertices[4].position, Vector(0, -1))
-        XCTAssertEqual(vertices[5].position, Vector(1, 0))
-        XCTAssertEqual(vertices[6].position, Vector(1, 0))
-        XCTAssertEqual(vertices[7].position, Vector(0, 1))
+        XCTAssertEqual(vertices[0].position, Position(0, 1))
+        XCTAssertEqual(vertices[1].position, Position(-1, 0))
+        XCTAssertEqual(vertices[2].position, Position(-1, 0))
+        XCTAssertEqual(vertices[3].position, Position(0, -1))
+        XCTAssertEqual(vertices[4].position, Position(0, -1))
+        XCTAssertEqual(vertices[5].position, Position(1, 0))
+        XCTAssertEqual(vertices[6].position, Position(1, 0))
+        XCTAssertEqual(vertices[7].position, Position(0, 1))
         // texture coords
         XCTAssertEqual(vertices[0].texcoord, Vector(0, 0))
         XCTAssertEqual(vertices[1].texcoord, Vector(0, 0.25))
@@ -419,14 +419,14 @@ class PathTests: XCTestCase {
         XCTAssertEqual(vertices.count, 8)
         guard vertices.count >= 8 else { return }
         // positions
-        XCTAssertEqual(vertices[0].position, Vector(0, 1))
-        XCTAssertEqual(vertices[1].position, Vector(-2, 0))
-        XCTAssertEqual(vertices[2].position, Vector(-2, 0))
-        XCTAssertEqual(vertices[3].position, Vector(0, -1))
-        XCTAssertEqual(vertices[4].position, Vector(0, -1))
-        XCTAssertEqual(vertices[5].position, Vector(2, 0))
-        XCTAssertEqual(vertices[6].position, Vector(2, 0))
-        XCTAssertEqual(vertices[7].position, Vector(0, 1))
+        XCTAssertEqual(vertices[0].position, Position(0, 1))
+        XCTAssertEqual(vertices[1].position, Position(-2, 0))
+        XCTAssertEqual(vertices[2].position, Position(-2, 0))
+        XCTAssertEqual(vertices[3].position, Position(0, -1))
+        XCTAssertEqual(vertices[4].position, Position(0, -1))
+        XCTAssertEqual(vertices[5].position, Position(2, 0))
+        XCTAssertEqual(vertices[6].position, Position(2, 0))
+        XCTAssertEqual(vertices[7].position, Position(0, 1))
         // texture coords
         XCTAssertEqual(vertices[0].texcoord, Vector(0, 0))
         XCTAssertEqual(vertices[1].texcoord, Vector(0, 0.25))
@@ -457,10 +457,10 @@ class PathTests: XCTestCase {
         XCTAssertEqual(vertices.count, 4)
         guard vertices.count >= 4 else { return }
         // positions
-        XCTAssertEqual(vertices[0].position, Vector(0, 1))
-        XCTAssertEqual(vertices[1].position, Vector(-1, 0))
-        XCTAssertEqual(vertices[2].position, Vector(-1, 0))
-        XCTAssertEqual(vertices[3].position, Vector(0, -1))
+        XCTAssertEqual(vertices[0].position, Position(0, 1))
+        XCTAssertEqual(vertices[1].position, Position(-1, 0))
+        XCTAssertEqual(vertices[2].position, Position(-1, 0))
+        XCTAssertEqual(vertices[3].position, Position(0, -1))
         // texture coords
         XCTAssertEqual(vertices[0].texcoord, Vector(0, 0))
         XCTAssertEqual(vertices[1].texcoord, Vector(0, 0.5))
@@ -482,8 +482,8 @@ class PathTests: XCTestCase {
         XCTAssertEqual(vertices.count, 2)
         guard vertices.count >= 2 else { return }
         // positions
-        XCTAssertEqual(vertices[0].position, Vector(-1, 1))
-        XCTAssertEqual(vertices[1].position, Vector(-1, -1))
+        XCTAssertEqual(vertices[0].position, Position(-1, 1))
+        XCTAssertEqual(vertices[1].position, Position(-1, -1))
         // texture coords
         XCTAssertEqual(vertices[0].texcoord, Vector(0, 0))
         XCTAssertEqual(vertices[1].texcoord, Vector(0, 1))
@@ -503,12 +503,12 @@ class PathTests: XCTestCase {
         XCTAssertEqual(vertices.count, 6)
         guard vertices.count >= 6 else { return }
         // positions
-        XCTAssertEqual(vertices[0].position, Vector(0, 0))
-        XCTAssertEqual(vertices[1].position, Vector(1, 0))
-        XCTAssertEqual(vertices[2].position, Vector(1, 0))
-        XCTAssertEqual(vertices[3].position, Vector(0, 1))
-        XCTAssertEqual(vertices[4].position, Vector(0, 1))
-        XCTAssertEqual(vertices[5].position, Vector(1, 1))
+        XCTAssertEqual(vertices[0].position, Position(0, 0))
+        XCTAssertEqual(vertices[1].position, Position(1, 0))
+        XCTAssertEqual(vertices[2].position, Position(1, 0))
+        XCTAssertEqual(vertices[3].position, Position(0, 1))
+        XCTAssertEqual(vertices[4].position, Position(0, 1))
+        XCTAssertEqual(vertices[5].position, Position(1, 1))
         // texture coords
         XCTAssertEqual(vertices[0].texcoord, Vector(0, 0))
         XCTAssertEqual(vertices[5].texcoord, Vector(0, 1))

--- a/Tests/PlaneTests.swift
+++ b/Tests/PlaneTests.swift
@@ -84,22 +84,22 @@ class PlaneTests: XCTestCase {
     // MARK: Intersections
 
     func testIntersectionWithParallelPlane() {
-        let plane1 = Plane(unchecked: .y, pointOnPlane: Vector(0, 0, 0))
-        let plane2 = Plane(unchecked: .y, pointOnPlane: Vector(0, 1, 0))
+        let plane1 = Plane(unchecked: .y, pointOnPlane: Position(0, 0, 0))
+        let plane2 = Plane(unchecked: .y, pointOnPlane: Position(0, 1, 0))
 
         XCTAssertNil(plane1.intersection(with: plane2))
     }
 
     func testIntersectionWithParallelPlaneInvertedNormal() {
-        let plane1 = Plane(unchecked: .y, pointOnPlane: Vector(0, 0, 0))
-        let plane2 = Plane(unchecked: -.y, pointOnPlane: Vector(0, 1, 0))
+        let plane1 = Plane(unchecked: .y, pointOnPlane: Position(0, 0, 0))
+        let plane2 = Plane(unchecked: -.y, pointOnPlane: Position(0, 1, 0))
 
         XCTAssertNil(plane1.intersection(with: plane2))
     }
 
     func testIntersectionWithPerpendicularPlane() {
-        let plane1 = Plane(unchecked: .y, pointOnPlane: Vector(0, 0, 0))
-        let plane2 = Plane(unchecked: .x, pointOnPlane: Vector(0, 0, 0))
+        let plane1 = Plane(unchecked: .y, pointOnPlane: Position(0, 0, 0))
+        let plane2 = Plane(unchecked: .x, pointOnPlane: Position(0, 0, 0))
 
         guard let intersection = plane1.intersection(with: plane2) else {
             XCTFail()
@@ -172,13 +172,13 @@ class PlaneTests: XCTestCase {
 
     func testIntersectWithParallelLine() {
         let line = Line(origin: .origin, direction: Direction(4, -5, 0))
-        let plane = Plane(unchecked: .z, pointOnPlane: Vector(-3, 2, 0))
+        let plane = Plane(unchecked: .z, pointOnPlane: Position(-3, 2, 0))
         XCTAssertNil(plane.intersection(with: line))
     }
 
     func testIntersectWithNormalLine() {
         let line = Line(origin: Position(1, 5, 60), direction: .z)
-        let plane = Plane(unchecked: .z, pointOnPlane: Vector(-3, 2, 0))
+        let plane = Plane(unchecked: .z, pointOnPlane: Position(-3, 2, 0))
         let expected = Position(1, 5, 0)
         XCTAssertEqual(expected, plane.intersection(with: line))
     }
@@ -192,7 +192,7 @@ class PlaneTests: XCTestCase {
 
     func testIntersectionWithSkewedLine() {
         let line = Line(origin: Position(8, 8, 10), direction: Direction(1, 1, 1))
-        let plane = Plane(unchecked: .z, pointOnPlane: Vector(5, -7, 2))
+        let plane = Plane(unchecked: .z, pointOnPlane: Position(5, -7, 2))
         let expected = Position(0, 0, 2)
         XCTAssertEqual(expected, plane.intersection(with: line))
     }

--- a/Tests/PolygonTests.swift
+++ b/Tests/PolygonTests.swift
@@ -27,10 +27,10 @@ class PolygonTests: XCTestCase {
     func testConvexPolygonAnticlockwiseWinding() {
         let normal = Direction.z
         guard let polygon = Polygon([
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(1, 1), normal),
         ]) else {
             XCTFail()
             return
@@ -41,10 +41,10 @@ class PolygonTests: XCTestCase {
     func testConvexPolygonClockwiseWinding() {
         let normal = -Direction.z
         guard let polygon = Polygon([
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(1, 1), normal),
-            Vertex(Vector(1, -1), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(1, 1), normal),
+            Vertex(Position(1, -1), normal),
         ]) else {
             XCTFail()
             return
@@ -55,12 +55,12 @@ class PolygonTests: XCTestCase {
     func testConcavePolygonAnticlockwiseWinding() {
         let normal = Direction.z
         guard let polygon = Polygon([
-            Vertex(Vector(-1, 0), normal),
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(1, 1), normal),
-            Vertex(Vector(-1, 1), normal),
+            Vertex(Position(-1, 0), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(1, 1), normal),
+            Vertex(Position(-1, 1), normal),
         ]) else {
             XCTFail()
             return
@@ -71,12 +71,12 @@ class PolygonTests: XCTestCase {
     func testConcavePolygonClockwiseWinding() {
         let normal = -Direction.z
         guard let polygon = Polygon([
-            Vertex(Vector(-1, 0), normal),
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(1, 1), normal),
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(-1, -1), normal),
+            Vertex(Position(-1, 0), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(1, 1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(-1, -1), normal),
         ]) else {
             XCTFail()
             return
@@ -87,38 +87,38 @@ class PolygonTests: XCTestCase {
     func testDegeneratePolygonWithColinearPoints() {
         let normal = Direction.z
         XCTAssertNil(Polygon([
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0, -2), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0, -2), normal),
         ]))
     }
 
     func testNonDegeneratePolygonWithColinearPoints() {
         let normal = Direction.z
         XCTAssertNotNil(Polygon([
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0, -2), normal),
-            Vertex(Vector(1.5, -1), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0, -2), normal),
+            Vertex(Position(1.5, -1), normal),
         ]))
     }
 
     func testDegeneratePolygonWithSelfIntersectingPoints() {
         let normal = Direction.z
         XCTAssertNil(Polygon([
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(1, 1), normal),
-            Vertex(Vector(1, 0), normal),
-            Vertex(Vector(0, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(1, 1), normal),
+            Vertex(Position(1, 0), normal),
+            Vertex(Position(0, 1), normal),
         ]))
     }
 
     func testZeroNormals() {
         guard let polygon = Polygon([
-            Vertex(Vector(-1, 1), .zero),
-            Vertex(Vector(-1, -1), .zero),
-            Vertex(Vector(1, -1), .zero),
-            Vertex(Vector(1, 1), .zero),
+            Vertex(Position(-1, 1), .zero),
+            Vertex(Position(-1, -1), .zero),
+            Vertex(Position(1, -1), .zero),
+            Vertex(Position(1, 1), .zero),
         ]) else {
             XCTFail()
             return
@@ -130,10 +130,10 @@ class PolygonTests: XCTestCase {
 
     func testPolygonFromVectors() {
         guard let polygon = Polygon([
-            Vector(-1, 1),
-            Vector(-1, -1),
-            Vector(1, -1),
-            Vector(1, 1),
+            Position(-1, 1),
+            Position(-1, -1),
+            Position(1, -1),
+            Position(1, 1),
         ]) else {
             XCTFail()
             return
@@ -148,20 +148,20 @@ class PolygonTests: XCTestCase {
     func testMerge1() {
         let normal = Direction.z
         let a = Polygon(unchecked: [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(1, 1), normal),
         ])
         let b = Polygon(unchecked: [
-            Vertex(Vector(1, 1), normal),
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(1, 0), normal),
+            Vertex(Position(1, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(1, 0), normal),
         ])
         let c = Polygon(unchecked: [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(1, 0), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(1, 0), normal),
+            Vertex(Position(1, 1), normal),
         ])
         XCTAssertEqual(a.merge(b), c)
     }
@@ -169,19 +169,19 @@ class PolygonTests: XCTestCase {
     func testMerge2() {
         let normal = Direction.z
         let a = Polygon(unchecked: [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(1, 0), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(1, 0), normal),
+            Vertex(Position(1, 1), normal),
         ])
         let b = Polygon(unchecked: [
-            Vertex(Vector(2, 1), normal),
-            Vertex(Vector(1, 1), normal),
-            Vertex(Vector(1, 0), normal),
+            Vertex(Position(2, 1), normal),
+            Vertex(Position(1, 1), normal),
+            Vertex(Position(1, 0), normal),
         ])
         let c = Polygon(unchecked: [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(1, 0), normal),
-            Vertex(Vector(2, 1), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(1, 0), normal),
+            Vertex(Position(2, 1), normal),
         ])
         XCTAssertEqual(a.merge(b), c)
     }
@@ -189,153 +189,153 @@ class PolygonTests: XCTestCase {
     func testMergeL2RAdjacentRects() {
         let normal = Direction.z
         let a = Polygon(unchecked: [
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(0, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(0, 1), normal),
         ])
         let b = Polygon(unchecked: [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(1, 1), normal),
         ])
         guard let c = a.merge(b) else {
             XCTFail()
             return
         }
         XCTAssertEqual(c, Polygon(unchecked: [
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(1, 1), normal),
         ]))
     }
 
     func testMergeR2LAdjacentRects() {
         let normal = Direction.z
         let a = Polygon(unchecked: [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(1, 1), normal),
         ])
         let b = Polygon(unchecked: [
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(0, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(0, 1), normal),
         ])
         guard let c = a.merge(b) else {
             XCTFail()
             return
         }
         XCTAssertEqual(c, Polygon(unchecked: [
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(1, 1), normal),
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, -1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(1, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, -1), normal),
         ]))
     }
 
     func testMergeB2TAdjacentRects() {
         let normal = Direction.z
         let a = Polygon(unchecked: [
-            Vertex(Vector(-1, 0), normal),
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(1, 0), normal),
+            Vertex(Position(-1, 0), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(1, 0), normal),
         ])
         let b = Polygon(unchecked: [
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, 0), normal),
-            Vertex(Vector(1, 0), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, 0), normal),
+            Vertex(Position(1, 0), normal),
+            Vertex(Position(1, 1), normal),
         ])
         guard let c = a.merge(b) else {
             XCTFail()
             return
         }
         XCTAssertEqual(c, Polygon(unchecked: [
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(1, 1), normal),
-            Vertex(Vector(-1, 1), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(1, 1), normal),
+            Vertex(Position(-1, 1), normal),
         ]))
     }
 
     func testMergeT2BAdjacentRects() {
         let normal = Direction.z
         let a = Polygon(unchecked: [
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, 0), normal),
-            Vertex(Vector(1, 0), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, 0), normal),
+            Vertex(Position(1, 0), normal),
+            Vertex(Position(1, 1), normal),
         ])
         let b = Polygon(unchecked: [
-            Vertex(Vector(-1, 0), normal),
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(1, -1), normal),
-            Vertex(Vector(1, 0), normal),
+            Vertex(Position(-1, 0), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(1, -1), normal),
+            Vertex(Position(1, 0), normal),
         ])
         guard let c = a.merge(b) else {
             XCTFail()
             return
         }
         XCTAssertEqual(c, Polygon(unchecked: [
-            Vertex(Vector(1, 1), normal),
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(1, -1), normal),
+            Vertex(Position(1, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(1, -1), normal),
         ]))
     }
 
     func testMergeL2RAdjacentRectAndTriangle() {
         let normal = Direction.z
         let a = Polygon(unchecked: [
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(0, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(0, 1), normal),
         ])
         let b = Polygon(unchecked: [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(1, 1), normal),
         ])
         guard let c = a.merge(b) else {
             XCTFail()
             return
         }
         XCTAssertEqual(c, Polygon(unchecked: [
-            Vertex(Vector(-1, 1), normal),
-            Vertex(Vector(-1, -1), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(1, 1), normal),
+            Vertex(Position(-1, 1), normal),
+            Vertex(Position(-1, -1), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(1, 1), normal),
         ]))
     }
 
     func testMergeEdgeCase() {
         let normal = Direction.z
         let a = Polygon(unchecked: [
-            Vertex(Vector(-0.02, 0.8), normal),
-            Vertex(Vector(0.7028203230300001, 0.38267949192000006), normal),
-            Vertex(Vector(0.7028203230300001, -0.38267949192000006), normal),
+            Vertex(Position(-0.02, 0.8), normal),
+            Vertex(Position(0.7028203230300001, 0.38267949192000006), normal),
+            Vertex(Position(0.7028203230300001, -0.38267949192000006), normal),
         ])
         let b = Polygon(unchecked: [
-            Vertex(Vector(0.7028203230300001, -0.38267949192000006), normal),
-            Vertex(Vector(-0.02, -0.8), normal),
-            Vertex(Vector(-0.6828203230300001, -0.41732050808000004), normal),
-            Vertex(Vector(-0.6828203230300001, 0.41732050808000004), normal),
-            Vertex(Vector(-0.02, 0.8), normal),
+            Vertex(Position(0.7028203230300001, -0.38267949192000006), normal),
+            Vertex(Position(-0.02, -0.8), normal),
+            Vertex(Position(-0.6828203230300001, -0.41732050808000004), normal),
+            Vertex(Position(-0.6828203230300001, 0.41732050808000004), normal),
+            Vertex(Position(-0.02, 0.8), normal),
         ])
         let c = Polygon(unchecked: [
-            Vertex(Vector(0.7028203230300001, 0.38267949192000006), normal),
-            Vertex(Vector(0.7028203230300001, -0.38267949192000006), normal),
-            Vertex(Vector(-0.02, -0.8), normal),
-            Vertex(Vector(-0.6828203230300001, -0.41732050808000004), normal),
-            Vertex(Vector(-0.6828203230300001, 0.41732050808000004), normal),
-            Vertex(Vector(-0.02, 0.8), normal),
+            Vertex(Position(0.7028203230300001, 0.38267949192000006), normal),
+            Vertex(Position(0.7028203230300001, -0.38267949192000006), normal),
+            Vertex(Position(-0.02, -0.8), normal),
+            Vertex(Position(-0.6828203230300001, -0.41732050808000004), normal),
+            Vertex(Position(-0.6828203230300001, 0.41732050808000004), normal),
+            Vertex(Position(-0.02, 0.8), normal),
         ])
         XCTAssertEqual(a.merge(b), c)
     }
@@ -354,15 +354,15 @@ class PolygonTests: XCTestCase {
             XCTFail()
             return
         }
-        XCTAssertTrue(polygon.containsPoint(Vector(0, 0)))
-        XCTAssertTrue(polygon.containsPoint(Vector(-0.999, 0.999)))
-        XCTAssertTrue(polygon.containsPoint(Vector(0.999, 0.999)))
-        XCTAssertTrue(polygon.containsPoint(Vector(0.999, -0.999)))
-        XCTAssertTrue(polygon.containsPoint(Vector(-0.999, -0.999)))
-        XCTAssertFalse(polygon.containsPoint(Vector(-1.001, 0)))
-        XCTAssertFalse(polygon.containsPoint(Vector(1.001, 0)))
-        XCTAssertFalse(polygon.containsPoint(Vector(0, -1.001)))
-        XCTAssertFalse(polygon.containsPoint(Vector(0, 1.001)))
+        XCTAssertTrue(polygon.containsPoint(Position(0, 0)))
+        XCTAssertTrue(polygon.containsPoint(Position(-0.999, 0.999)))
+        XCTAssertTrue(polygon.containsPoint(Position(0.999, 0.999)))
+        XCTAssertTrue(polygon.containsPoint(Position(0.999, -0.999)))
+        XCTAssertTrue(polygon.containsPoint(Position(-0.999, -0.999)))
+        XCTAssertFalse(polygon.containsPoint(Position(-1.001, 0)))
+        XCTAssertFalse(polygon.containsPoint(Position(1.001, 0)))
+        XCTAssertFalse(polygon.containsPoint(Position(0, -1.001)))
+        XCTAssertFalse(polygon.containsPoint(Position(0, 1.001)))
     }
 
     func testConvexClockwisePolygonContainsPoint() {
@@ -377,15 +377,15 @@ class PolygonTests: XCTestCase {
             XCTFail()
             return
         }
-        XCTAssertTrue(polygon.containsPoint(Vector(0, 0)))
-        XCTAssertTrue(polygon.containsPoint(Vector(-0.999, 0.999)))
-        XCTAssertTrue(polygon.containsPoint(Vector(0.999, 0.999)))
-        XCTAssertTrue(polygon.containsPoint(Vector(0.999, -0.999)))
-        XCTAssertTrue(polygon.containsPoint(Vector(-0.999, -0.999)))
-        XCTAssertFalse(polygon.containsPoint(Vector(-1.001, 0)))
-        XCTAssertFalse(polygon.containsPoint(Vector(1.001, 0)))
-        XCTAssertFalse(polygon.containsPoint(Vector(0, -1.001)))
-        XCTAssertFalse(polygon.containsPoint(Vector(0, 1.001)))
+        XCTAssertTrue(polygon.containsPoint(Position(0, 0)))
+        XCTAssertTrue(polygon.containsPoint(Position(-0.999, 0.999)))
+        XCTAssertTrue(polygon.containsPoint(Position(0.999, 0.999)))
+        XCTAssertTrue(polygon.containsPoint(Position(0.999, -0.999)))
+        XCTAssertTrue(polygon.containsPoint(Position(-0.999, -0.999)))
+        XCTAssertFalse(polygon.containsPoint(Position(-1.001, 0)))
+        XCTAssertFalse(polygon.containsPoint(Position(1.001, 0)))
+        XCTAssertFalse(polygon.containsPoint(Position(0, -1.001)))
+        XCTAssertFalse(polygon.containsPoint(Position(0, 1.001)))
     }
 
     func testConcaveAnticlockwisePolygonContainsPoint() {
@@ -402,10 +402,10 @@ class PolygonTests: XCTestCase {
             XCTFail()
             return
         }
-        XCTAssertTrue(polygon.containsPoint(Vector(-0.5, 0.5)))
-        XCTAssertTrue(polygon.containsPoint(Vector(0.5, 0.5)))
-        XCTAssertFalse(polygon.containsPoint(Vector(-0.5, -0.5)))
-        XCTAssertTrue(polygon.containsPoint(Vector(0.5, -0.5)))
+        XCTAssertTrue(polygon.containsPoint(Position(-0.5, 0.5)))
+        XCTAssertTrue(polygon.containsPoint(Position(0.5, 0.5)))
+        XCTAssertFalse(polygon.containsPoint(Position(-0.5, -0.5)))
+        XCTAssertTrue(polygon.containsPoint(Position(0.5, -0.5)))
     }
 
     func testConcaveAnticlockwisePolygonContainsPoint2() {
@@ -420,12 +420,12 @@ class PolygonTests: XCTestCase {
             XCTFail()
             return
         }
-        XCTAssertTrue(polygon.containsPoint(Vector(0.75, 0)))
-        XCTAssertFalse(polygon.containsPoint(Vector(0.25, 0)))
-        XCTAssertFalse(polygon.containsPoint(Vector(0.25, 0.25)))
-        XCTAssertFalse(polygon.containsPoint(Vector(0.25, -0.25)))
-        XCTAssertTrue(polygon.containsPoint(Vector(0.25, 0.5)))
-        XCTAssertTrue(polygon.containsPoint(Vector(0.25, -0.5)))
+        XCTAssertTrue(polygon.containsPoint(Position(0.75, 0)))
+        XCTAssertFalse(polygon.containsPoint(Position(0.25, 0)))
+        XCTAssertFalse(polygon.containsPoint(Position(0.25, 0.25)))
+        XCTAssertFalse(polygon.containsPoint(Position(0.25, -0.25)))
+        XCTAssertTrue(polygon.containsPoint(Position(0.25, 0.5)))
+        XCTAssertTrue(polygon.containsPoint(Position(0.25, -0.5)))
     }
 
     // MARK: tessellation
@@ -449,15 +449,15 @@ class PolygonTests: XCTestCase {
         }
         let a = Set(polygons[0].vertices.map { $0.position })
         let expectedA = Set([
-            Vector(0, 1),
-            Vector(0.5, 0),
-            Vector(1, 0),
+            Position(0, 1),
+            Position(0.5, 0),
+            Position(1, 0),
         ])
         let b = Set(polygons[1].vertices.map { $0.position })
         let expectedB = Set([
-            Vector(0.5, 0),
-            Vector(1, 0),
-            Vector(0, -1),
+            Position(0.5, 0),
+            Position(1, 0),
+            Position(0, -1),
         ])
         XCTAssert(a == expectedA || a == expectedB)
         XCTAssert(b == expectedA || b == expectedB)
@@ -482,15 +482,15 @@ class PolygonTests: XCTestCase {
         }
         let a = Set(polygons[0].vertices.map { $0.position })
         let expectedA = Set([
-            Vector(0, 1),
-            Vector(1, 0),
-            Vector(0.5, 0),
+            Position(0, 1),
+            Position(1, 0),
+            Position(0.5, 0),
         ])
         let b = Set(polygons[1].vertices.map { $0.position })
         let expectedB = Set([
-            Vector(0.5, 0),
-            Vector(1, 0),
-            Vector(0, -1),
+            Position(0.5, 0),
+            Position(1, 0),
+            Position(0, -1),
         ])
         XCTAssert(a == expectedA || a == expectedB)
         XCTAssert(b == expectedA || b == expectedB)
@@ -517,15 +517,15 @@ class PolygonTests: XCTestCase {
         }
         let a = Set(triangles[0].vertices.map { $0.position })
         let expectedA = Set([
-            Vector(0, 1),
-            Vector(0.5, 0),
-            Vector(1, 0),
+            Position(0, 1),
+            Position(0.5, 0),
+            Position(1, 0),
         ])
         let b = Set(triangles[1].vertices.map { $0.position })
         let expectedB = Set([
-            Vector(0.5, 0),
-            Vector(1, 0),
-            Vector(0, -1),
+            Position(0.5, 0),
+            Position(1, 0),
+            Position(0, -1),
         ])
         XCTAssert(a == expectedA || a == expectedB)
         XCTAssert(b == expectedA || b == expectedB)
@@ -550,15 +550,15 @@ class PolygonTests: XCTestCase {
         }
         let a = Set(triangles[0].vertices.map { $0.position })
         let expectedA = Set([
-            Vector(0, 1),
-            Vector(1, 0),
-            Vector(0.5, 0),
+            Position(0, 1),
+            Position(1, 0),
+            Position(0.5, 0),
         ])
         let b = Set(triangles[1].vertices.map { $0.position })
         let expectedB = Set([
-            Vector(0.5, 0),
-            Vector(1, 0),
-            Vector(0, -1),
+            Position(0.5, 0),
+            Position(1, 0),
+            Position(0, -1),
         ])
         XCTAssert(a == expectedA || a == expectedB)
         XCTAssert(b == expectedA || b == expectedB)
@@ -567,11 +567,11 @@ class PolygonTests: XCTestCase {
     func testPolygonWithColinearPointsCorrectlyTriangulated() {
         let normal = -Direction.z
         guard let polygon = Polygon([
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0.5, 0), normal),
-            Vertex(Vector(0.5, 1), normal),
-            Vertex(Vector(-0.5, 1), normal),
-            Vertex(Vector(-0.5, 0), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0.5, 0), normal),
+            Vertex(Position(0.5, 1), normal),
+            Vertex(Position(-0.5, 1), normal),
+            Vertex(Position(-0.5, 0), normal),
         ]) else {
             XCTFail()
             return
@@ -582,32 +582,32 @@ class PolygonTests: XCTestCase {
             return
         }
         XCTAssertEqual(triangles[0], Polygon([
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0.5, 0), normal),
-            Vertex(Vector(0.5, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0.5, 0), normal),
+            Vertex(Position(0.5, 1), normal),
         ]))
         XCTAssertEqual(triangles[1], Polygon([
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0.5, 1), normal),
-            Vertex(Vector(-0.5, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0.5, 1), normal),
+            Vertex(Position(-0.5, 1), normal),
         ]))
         XCTAssertEqual(triangles[2], Polygon([
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(-0.5, 1), normal),
-            Vertex(Vector(-0.5, 0), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(-0.5, 1), normal),
+            Vertex(Position(-0.5, 0), normal),
         ]))
     }
 
     func testHouseShapedPolygonCorrectlyTriangulated() {
         let normal = -Direction.z
         guard let polygon = Polygon([
-            Vertex(Vector(0, 0.5), normal),
-            Vertex(Vector(1, 0), normal),
-            Vertex(Vector(0.5, -epsilon), normal),
-            Vertex(Vector(0.5, -1), normal),
-            Vertex(Vector(-0.5, -1), normal),
-            Vertex(Vector(-0.5, -epsilon), normal),
-            Vertex(Vector(-1, 0), normal),
+            Vertex(Position(0, 0.5), normal),
+            Vertex(Position(1, 0), normal),
+            Vertex(Position(0.5, -epsilon), normal),
+            Vertex(Position(0.5, -1), normal),
+            Vertex(Position(-0.5, -1), normal),
+            Vertex(Position(-0.5, -epsilon), normal),
+            Vertex(Position(-1, 0), normal),
         ]) else {
             XCTFail()
             return
@@ -618,19 +618,19 @@ class PolygonTests: XCTestCase {
             return
         }
         XCTAssertEqual(triangles[0], Polygon([
-            Vertex(Vector(-1, 0), normal),
-            Vertex(Vector(0, 0.5), normal),
-            Vertex(Vector(1, 0), normal),
+            Vertex(Position(-1, 0), normal),
+            Vertex(Position(0, 0.5), normal),
+            Vertex(Position(1, 0), normal),
         ]))
         XCTAssertEqual(triangles[1], Polygon([
-            Vertex(Vector(0.5, -epsilon), normal),
-            Vertex(Vector(0.5, -1), normal),
-            Vertex(Vector(-0.5, -1), normal),
+            Vertex(Position(0.5, -epsilon), normal),
+            Vertex(Position(0.5, -1), normal),
+            Vertex(Position(-0.5, -1), normal),
         ]))
         XCTAssertEqual(triangles[2], Polygon([
-            Vertex(Vector(0.5, -epsilon), normal),
-            Vertex(Vector(-0.5, -1), normal),
-            Vertex(Vector(-0.5, -epsilon), normal),
+            Vertex(Position(0.5, -epsilon), normal),
+            Vertex(Position(-0.5, -1), normal),
+            Vertex(Position(-0.5, -epsilon), normal),
         ]))
     }
 
@@ -671,19 +671,19 @@ class PolygonTests: XCTestCase {
         let points = triangles.map { $0.vertices.map { $0.position } }
         XCTAssertEqual(points, [
             [
-                Vector(0.9349999999999999, 0.0, 0.16999999999999998),
-                Vector(1.086, 0.0, 0.16999999999999998),
-                Vector(1.086, 0.0, 0.13999999999999999),
+                Position(0.9349999999999999, 0.0, 0.16999999999999998),
+                Position(1.086, 0.0, 0.16999999999999998),
+                Position(1.086, 0.0, 0.13999999999999999),
             ],
             [
-                Vector(0.9349999999999999, 0.0, 0.16999999999999998),
-                Vector(1.086, 0.0, 0.13999999999999999),
-                Vector(0.95, offset, 0.13999999999999999),
+                Position(0.9349999999999999, 0.0, 0.16999999999999998),
+                Position(1.086, 0.0, 0.13999999999999999),
+                Position(0.95, offset, 0.13999999999999999),
             ],
             [
-                Vector(0.95, offset, 0.13999999999999999),
-                Vector(0.9349999999999999, 0.0, 0.09999999999999999),
-                Vector(0.9349999999999999, 0.0, 0.16999999999999998),
+                Position(0.95, offset, 0.13999999999999999),
+                Position(0.9349999999999999, 0.0, 0.09999999999999999),
+                Position(0.9349999999999999, 0.0, 0.16999999999999998),
             ],
         ])
         let merged = triangles.detessellate(ensureConvex: false)
@@ -709,19 +709,19 @@ class PolygonTests: XCTestCase {
         let points = triangles.map { $0.vertices.map { $0.position } }
         XCTAssertEqual(points, [
             [
-                Vector(1.086, 0.0, 0.13999999999999999),
-                Vector(1.086, 0.0, 0.16999999999999998),
-                Vector(0.9349999999999999, 0.0, 0.16999999999999998),
+                Position(1.086, 0.0, 0.13999999999999999),
+                Position(1.086, 0.0, 0.16999999999999998),
+                Position(0.9349999999999999, 0.0, 0.16999999999999998),
             ],
             [
-                Vector(0.95, offset, 0.13999999999999999),
-                Vector(1.086, 0.0, 0.13999999999999999),
-                Vector(0.9349999999999999, 0.0, 0.16999999999999998),
+                Position(0.95, offset, 0.13999999999999999),
+                Position(1.086, 0.0, 0.13999999999999999),
+                Position(0.9349999999999999, 0.0, 0.16999999999999998),
             ],
             [
-                Vector(0.9349999999999999, 0.0, 0.16999999999999998),
-                Vector(0.9349999999999999, 0.0, 0.09999999999999999),
-                Vector(0.95, offset, 0.13999999999999999),
+                Position(0.9349999999999999, 0.0, 0.16999999999999998),
+                Position(0.9349999999999999, 0.0, 0.09999999999999999),
+                Position(0.95, offset, 0.13999999999999999),
             ],
         ])
         let merged = triangles.detessellate(ensureConvex: false)
@@ -805,11 +805,11 @@ class PolygonTests: XCTestCase {
     func testPolygonWithColinearPointsCorrectlyDetessellated() {
         let normal = -Direction.z
         let polygon = Polygon(unchecked: [
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0.5, 0), normal),
-            Vertex(Vector(0.5, 1), normal),
-            Vertex(Vector(-0.5, 1), normal),
-            Vertex(Vector(-0.5, 0), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0.5, 0), normal),
+            Vertex(Position(0.5, 1), normal),
+            Vertex(Position(-0.5, 1), normal),
+            Vertex(Position(-0.5, 0), normal),
         ])
         let triangles = polygon.triangulate()
         XCTAssertEqual(triangles.count, 3)
@@ -822,13 +822,13 @@ class PolygonTests: XCTestCase {
     func testHouseShapedPolygonCorrectlyDetessellated() {
         let normal = -Direction.z
         let polygon = Polygon(unchecked: [
-            Vertex(Vector(0, 0.5), normal),
-            Vertex(Vector(1, 0), normal),
-            Vertex(Vector(0.5, 0), normal),
-            Vertex(Vector(0.5, -1), normal),
-            Vertex(Vector(-0.5, -1), normal),
-            Vertex(Vector(-0.5, 0), normal),
-            Vertex(Vector(-1, 0), normal),
+            Vertex(Position(0, 0.5), normal),
+            Vertex(Position(1, 0), normal),
+            Vertex(Position(0.5, 0), normal),
+            Vertex(Position(0.5, -1), normal),
+            Vertex(Position(-0.5, -1), normal),
+            Vertex(Position(-0.5, 0), normal),
+            Vertex(Position(-1, 0), normal),
         ])
         let triangles = polygon.triangulate()
         XCTAssertEqual(triangles.count, 5)
@@ -842,29 +842,29 @@ class PolygonTests: XCTestCase {
         let normal = -Direction.z
         let triangles = [
             Polygon(unchecked: [
-                Vertex(Vector(0, -1), normal),
-                Vertex(Vector(-2, 0), normal),
-                Vertex(Vector(2, 0), normal),
+                Vertex(Position(0, -1), normal),
+                Vertex(Position(-2, 0), normal),
+                Vertex(Position(2, 0), normal),
             ]),
             Polygon(unchecked: [
-                Vertex(Vector(-2, 0), normal),
-                Vertex(Vector(0, 1), normal),
-                Vertex(Vector(0, 0), normal),
+                Vertex(Position(-2, 0), normal),
+                Vertex(Position(0, 1), normal),
+                Vertex(Position(0, 0), normal),
             ]),
             Polygon(unchecked: [
-                Vertex(Vector(2, 0), normal),
-                Vertex(Vector(0, 0), normal),
-                Vertex(Vector(0, 1), normal),
+                Vertex(Position(2, 0), normal),
+                Vertex(Position(0, 0), normal),
+                Vertex(Position(0, 1), normal),
             ]),
         ]
         let result = triangles.detessellate()
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result, [
             Polygon(unchecked: [
-                Vertex(Vector(0, -1), normal),
-                Vertex(Vector(-2, 0), normal),
-                Vertex(Vector(0, 1), normal),
-                Vertex(Vector(2, 0), normal),
+                Vertex(Position(0, -1), normal),
+                Vertex(Position(-2, 0), normal),
+                Vertex(Position(0, 1), normal),
+                Vertex(Position(2, 0), normal),
             ]),
         ])
     }

--- a/Tests/PositionTests.swift
+++ b/Tests/PositionTests.swift
@@ -53,13 +53,13 @@ class PositionTests: XCTestCase {
 
     func testDistanceInFrontOfPlane() {
         let position = Position(2, 1, -2)
-        let plane = Plane(unchecked: .x, pointOnPlane: Vector.zero)
+        let plane = Plane(unchecked: .x, pointOnPlane: .origin)
         XCTAssertEqual(position.distance(from: plane), 2)
     }
 
     func testDistanceBehindPlane() {
         let position = Position(-1.5, 2, 7)
-        let plane = Plane(unchecked: .x, pointOnPlane: Vector.zero)
+        let plane = Plane(unchecked: .x, pointOnPlane: .origin)
         XCTAssertEqual(position.distance(from: plane), -1.5)
     }
 }

--- a/Tests/ShapeTests.swift
+++ b/Tests/ShapeTests.swift
@@ -225,7 +225,7 @@ class ShapeTests: XCTestCase {
         // Every vertex in the loft should be contained by one of our shapes
         let vertices = loft.polygons.flatMap { $0.vertices }
         XCTAssert(vertices.allSatisfy { vertex in
-            shapes.contains(where: { $0.points.contains(where: { $0.position == Position(vertex.position) }) })
+            shapes.contains(where: { $0.points.contains(where: { $0.position == vertex.position }) })
         })
     }
 
@@ -248,7 +248,7 @@ class ShapeTests: XCTestCase {
         // Every vertex in the loft should be contained by one of our shapes
         let vertices = loft.polygons.flatMap { $0.vertices }
         XCTAssert(vertices.allSatisfy { vertex in
-            shapes.contains(where: { $0.points.contains(where: { $0.position == Position(vertex.position) }) })
+            shapes.contains(where: { $0.points.contains(where: { $0.position == vertex.position }) })
         })
     }
 

--- a/Tests/TransformTests.swift
+++ b/Tests/TransformTests.swift
@@ -242,16 +242,16 @@ class TransformTests: XCTestCase {
 
     func testTranslatePlane() {
         let normal = Direction(0.5, 1, 0.5)
-        let position = Vector(10, 5, -3)
+        let position = Position(10, 5, -3)
         let plane = Plane(unchecked: normal, pointOnPlane: position)
         let offset = Distance(12, 3, 4)
-        let expected = Plane(unchecked: normal, pointOnPlane: position + Vector(offset))
+        let expected = Plane(unchecked: normal, pointOnPlane: position + offset)
         XCTAssert(plane.translated(by: offset).isEqual(to: expected))
     }
 
     func testRotatePlane() {
         let normal = Direction(0.5, 1, 0.5)
-        let position = Vector(10, 5, -3)
+        let position = Position(10, 5, -3)
         let plane = Plane(unchecked: normal, pointOnPlane: position)
         let rotation = Rotation(axis: Direction(12, 3, 4), angle: .radians(0.2))
         let rotatedNormal = normal.rotated(by: rotation)
@@ -262,7 +262,7 @@ class TransformTests: XCTestCase {
 
     func testScalePlane() {
         let normal = Direction(0.5, 1, 0.5)
-        let position = Vector(10, 5, -3)
+        let position = Position(10, 5, -3)
         let plane = Plane(unchecked: normal, pointOnPlane: position)
         let scale = Distance(0.5, 3.0, 0.1)
         let expectedNormal = normal.scaled(by: Distance(1 / scale.x, 1 / scale.y, 1 / scale.z))
@@ -272,10 +272,10 @@ class TransformTests: XCTestCase {
 
     func testScalePlaneUniformly() {
         let normal = Direction(0.5, 1, 0.5)
-        let position = Vector(10, 5, -3)
+        let position = Position(10, 5, -3)
         let plane = Plane(unchecked: normal, pointOnPlane: position)
         let scale = 0.5
-        let expected = Plane(unchecked: normal, pointOnPlane: position * scale)
+        let expected = Plane(unchecked: normal, pointOnPlane: position.scaled(by: scale))
         XCTAssert(plane.scaled(by: scale).isEqual(to: expected))
     }
 

--- a/Tests/UtilityTests.swift
+++ b/Tests/UtilityTests.swift
@@ -22,7 +22,7 @@ class UtilityTests: XCTestCase {
         ]
         XCTAssertTrue(pointsAreConvex(vectors))
         let offset = Distance(0, 0, 3)
-        let vertices = vectors.map { Vertex(Vector($0), .y).translated(by: offset) }
+        let vertices = vectors.map { Vertex($0, .y).translated(by: offset) }
         XCTAssertTrue(verticesAreConvex(vertices))
     }
 
@@ -41,9 +41,9 @@ class UtilityTests: XCTestCase {
     func testDegenerateColinearVertices() {
         let normal = Direction.z
         let vertices = [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0, -2), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0, -2), normal),
         ]
         XCTAssertTrue(verticesAreDegenerate(vertices))
     }
@@ -51,10 +51,10 @@ class UtilityTests: XCTestCase {
     func testNonDegenerateColinearVertices() {
         let normal = Direction.z
         let vertices = [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, 0), normal),
-            Vertex(Vector(0, -2), normal),
-            Vertex(Vector(1.5, -1), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, 0), normal),
+            Vertex(Position(0, -2), normal),
+            Vertex(Position(1.5, -1), normal),
         ]
         XCTAssertFalse(verticesAreDegenerate(vertices))
     }
@@ -62,10 +62,10 @@ class UtilityTests: XCTestCase {
     func testDegenerateVerticesWithZeroLengthEdge() {
         let normal = Direction.z
         let vertices = [
-            Vertex(Vector(0, 1), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(0, -1), normal),
-            Vertex(Vector(1.5, 0), normal),
+            Vertex(Position(0, 1), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(0, -1), normal),
+            Vertex(Position(1.5, 0), normal),
         ]
         XCTAssertTrue(verticesAreDegenerate(vertices))
     }

--- a/Tests/VectorTests.swift
+++ b/Tests/VectorTests.swift
@@ -41,7 +41,7 @@ class VectorTests: XCTestCase {
 
     func testRightAngleWithPlane() {
         let direction = Vector(1, 0, 0)
-        let plane = Plane(unchecked: .x, pointOnPlane: Vector.zero)
+        let plane = Plane(unchecked: .x, pointOnPlane: .origin)
         XCTAssertEqual(direction.angle(with: plane), .halfPi)
     }
 }


### PR DESCRIPTION
Overview of remaining refactoring steps from #37:

`line.origin` -> `Position` _[done]_
`lineSegment.start/end` -> `Position` _[done]_
`pathPoint.position` -> `Position` _[done]_
`transform.offset` -> `Distance` _[done]_
`transform.scale` -> `Distance` _[done]_
`vertex.position` -> `Position` **[this PR]**
`Plane(normal: Direction, pointOnPlane: Vector)` -> `pointOnPlane` should be `Position` **[this PR]**