### PR TITLE
Add method to inset polygon vertices

### DIFF
--- a/Sources/Polygon+CSG.swift
+++ b/Sources/Polygon+CSG.swift
@@ -245,3 +245,31 @@ extension Polygon {
         return false
     }
 }
+
+public extension Polygon {
+    func inset(by t: Double) -> Self? {
+        var v: [Vertex] = []
+
+        for i in orderedEdges.indices {
+            let e0 = orderedEdges[i]
+            let e1 = orderedEdges[(i + 1) % orderedEdges.count]
+
+            let p0 = edgePlane(for: e0)
+            let p1 = edgePlane(for: e1)
+
+            let normal = -(p0.normal + p1.normal).normalized() * t
+
+            let p2 = p0.translated(by: normal)
+            let p3 = p1.translated(by: normal)
+
+            let vector = vertices.first { $0.position.isEqual(to: e0.end) }
+
+            guard let vector,
+                  let intersection = p2.intersection(with: p3) else { return nil }
+
+            v.append(Vertex(intersection.origin, vector.normal, vector.texcoord, vector.color))
+        }
+
+        return Self(v)
+    }
+}

--- a/Sources/Polygon+CSG.swift
+++ b/Sources/Polygon+CSG.swift
@@ -248,24 +248,22 @@ extension Polygon {
 
 public extension Polygon {
     func inset(by t: Double) -> Self? {
-        var v: [Vertex] = []
-
-        for i in orderedEdges.indices {
-            let e0 = orderedEdges[i]
-            let e1 = orderedEdges[(i + 1) % orderedEdges.count]
+        let v: [Vertex] = orderedEdges.indices.compactMap {
+            let e0 = orderedEdges[$0]
+            let e1 = orderedEdges[($0 + 1) % orderedEdges.count]
 
             let p0 = edgePlane(for: e0)
             let p1 = edgePlane(for: e1)
 
-            let p2 = p0.translated(by: -p0.normal * t)
-            let p3 = p1.translated(by: -p1.normal * t)
+            let lhs = p0.translated(by: -p0.normal * t)
+            let rhs = p1.translated(by: -p1.normal * t)
 
-            let vector = vertices.first { $0.position.isEqual(to: e0.end) }
+            let vertex = vertices.first { $0.position.isEqual(to: e0.end) }
 
-            guard let vector,
-                  let intersection = p2.intersection(with: p3) else { return nil }
+            guard let vertex,
+                  let intersection = lhs.intersection(with: rhs) else { return nil }
 
-            v.append(Vertex(intersection.origin, vector.normal, vector.texcoord, vector.color))
+            return Vertex(intersection.origin, vertex.normal, vertex.texcoord, vertex.color)
         }
 
         return Self(v)

--- a/Sources/Polygon+CSG.swift
+++ b/Sources/Polygon+CSG.swift
@@ -257,10 +257,8 @@ public extension Polygon {
             let p0 = edgePlane(for: e0)
             let p1 = edgePlane(for: e1)
 
-            let normal = -(p0.normal + p1.normal).normalized() * t
-
-            let p2 = p0.translated(by: normal)
-            let p3 = p1.translated(by: normal)
+            let p2 = p0.translated(by: -p0.normal * t)
+            let p3 = p1.translated(by: -p1.normal * t)
 
             let vector = vertices.first { $0.position.isEqual(to: e0.end) }
 


### PR DESCRIPTION
# Description

Implements a new method to inset the vertices of a polygon by a given amount by iterating through edge segment pairs to find a common point of intersection between the two translated planes.

<img width="182" alt="polygon_inset" src="https://github.com/nicklockwood/Euclid/assets/197710/14825134-706f-4374-a397-d3719204831f">

## Scope of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] The project builds successfully without generating errors
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] No force unwrapping and all optionals are guarded against / safely checked

# Discussion

Whilst this does appear to yield the correct results, I am unsure if there is a more performant means to achieve the same output. 

Searching for the appropriate vertex arbitrarily choosing either `e0.end` or `e1.start` via

    let vector = vertices.first { $0.position.isEqual(to: e0.end) } 

to retain the vertex normal, texture coordinates and color seems like a brittle approach. I can not think of an alternative means to tie the translated vertices back to the original vertex - perhaps you can?

As an aside; I note that a [dispacement modifier was suggested here](https://github.com/nicklockwood/Euclid/issues/83) but I am unable to find any implementation of `Mesh.inset()` - has this been removed?