### PR TITLE
Change to README.md to provide the most current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ Euclid is packaged as a dynamic framework that you can import into your Xcode pr
 To install Euclid using CocoaPods, add the following to your Podfile:
 
 ```ruby
-pod 'Euclid', '~> 0.6'
+pod 'Euclid', '~> 0.7.7'
 ```
 
 To install using Carthage, add this to your Cartfile:
 
 ```ogdl
-github "nicklockwood/Euclid" ~> 0.6
+github "nicklockwood/Euclid" ~> 0.7.7
 ```
 
 To install using Swift Package Manager, add this to the `dependencies:` section in your Package.swift file:
 
 ```swift
-.package(url: "https://github.com/nicklockwood/Euclid.git", .upToNextMinor(from: "0.6.0")),
+.package(url: "https://github.com/nicklockwood/Euclid.git", .upToNextMinor(from: "0.7.7")),
 ```
 
 

--- a/Sources/Mesh+IO.swift
+++ b/Sources/Mesh+IO.swift
@@ -75,22 +75,26 @@ public extension Mesh {
             try string.write(to: url, atomically: true, encoding: .utf8)
             #endif
         default:
-            #if canImport(SceneKit)
-            let scnScene = SCNScene()
-            let materialLookup = materialLookup.map { lookup in { defaultMaterialLookup(lookup($0)) } }
-            let geometry = SCNGeometry(polygons: self, materialLookup: materialLookup)
-            scnScene.rootNode.addChildNode(SCNNode(geometry: geometry))
-            guard scnScene.write(
-                to: url,
-                options: [:],
-                delegate: nil,
-                progressHandler: nil
-            ) else {
-                throw IOError("Failed to export file")
-            }
-            #else
-            throw IOError("Unsupported mesh file format '\(url.pathExtension)'")
-            #endif
+            #if os(watchOS)
+			throw IOError("Cannot export '\(url.pathExtension)' on watchOS.")
+			#else
+				#if canImport(SceneKit)
+				let scnScene = SCNScene()
+				let materialLookup = materialLookup.map { lookup in { defaultMaterialLookup(lookup($0)) } }
+				let geometry = SCNGeometry(polygons: self, materialLookup: materialLookup)
+				scnScene.rootNode.addChildNode(SCNNode(geometry: geometry))
+				guard scnScene.write(
+					to: url,
+					options: [:],
+					delegate: nil,
+					progressHandler: nil
+				) else {
+					throw IOError("Failed to export file")
+				}
+				#else
+				throw IOError("Unsupported mesh file format '\(url.pathExtension)'")
+				#endif
+			#endif
         }
     }
 }


### PR DESCRIPTION
Current README.md points to a version from 2022, which is less than useful for visionOS development.