### PR TITLE
Support for partial lathes (and by extension partial cylinders)

### DIFF
--- a/Sources/Angle.swift
+++ b/Sources/Angle.swift
@@ -206,6 +206,12 @@ public extension Angle {
     }
 }
 
+public extension Angle {
+    func lerp(_ other: Angle, _ t: Double) -> Angle {
+        return self + (other - self) * t
+    }
+}
+
 extension Angle {
     /// Approximate equality
     func isEqual(to other: Angle, withPrecision p: Double = epsilon) -> Bool {

--- a/Sources/Mesh+Shapes.swift
+++ b/Sources/Mesh+Shapes.swift
@@ -312,6 +312,8 @@ public extension Mesh {
     static func cylinder(
         radius: Double = 0.5,
         height: Double = 1,
+        startAngle: Angle = .zero,
+        endAngle: Angle = .twoPi,
         slices: Int = 16,
         poleDetail: Int = 0,
         faces: Faces = .default,
@@ -331,6 +333,8 @@ public extension Mesh {
                 .point(-radius, 0),
                 .point(0, 0),
             ], plane: .xy, subpathIndices: []),
+            startAngle: startAngle,
+            endAngle: endAngle,
             slices: slices,
             poleDetail: poleDetail,
             addDetailForFlatPoles: true,
@@ -407,6 +411,8 @@ public extension Mesh {
     ///   - material: The optional material for the mesh.
     static func lathe(
         _ profile: Path,
+        startAngle: Angle = .zero,
+        endAngle: Angle = .twoPi,
         slices: Int = 16,
         poleDetail: Int = 0,
         addDetailForFlatPoles: Bool = false,
@@ -416,6 +422,8 @@ public extension Mesh {
     ) -> Mesh {
         lathe(
             unchecked: profile,
+            startAngle: startAngle,
+            endAngle: endAngle,
             slices: slices,
             poleDetail: poleDetail,
             addDetailForFlatPoles: addDetailForFlatPoles,
@@ -903,6 +911,8 @@ private extension Mesh {
 
     static func lathe(
         unchecked profile: Path,
+        startAngle: Angle = .zero,
+        endAngle: Angle = .twoPi,
         slices: Int = 16,
         poleDetail: Int = 0,
         addDetailForFlatPoles: Bool = false,
@@ -917,6 +927,8 @@ private extension Mesh {
             return .symmetricDifference(subpaths.map {
                 .lathe(
                     $0,
+                    startAngle: startAngle,
+                    endAngle: endAngle,
                     slices: slices,
                     poleDetail: poleDetail,
                     addDetailForFlatPoles: addDetailForFlatPoles,
@@ -974,8 +986,8 @@ private extension Mesh {
         for i in 0 ..< slices {
             let t0 = Double(i) / Double(slices)
             let t1 = Double(i + 1) / Double(slices)
-            let a0 = t0 * Angle.twoPi
-            let a1 = t1 * Angle.twoPi.radians
+            let a0 = startAngle.lerp(endAngle, t0)
+            let a1 = startAngle.lerp(endAngle, t1)
             let cos0 = cos(a0)
             let cos1 = cos(a1)
             let sin0 = sin(a0)


### PR DESCRIPTION
I've run into some situations now where i would profit from the ability to only partially complete a lathes rotation giving us the ability to easily create partial cylinders and other more complex structures as seen in the image below.
<img width="50%" src="https://github.com/user-attachments/assets/4cb61e46-1d72-4a76-97a1-b0fe88cdb49d">
`Mesh.cylinder(endAngle: .halfPi)`

The current state of the pr is a very rough draft of the functionality without any documentation changes as i believe there are a few implementation details that we should discuss if a merge is desired.

### How should the functionality be integrated?
I quite like the current solution of adding two more arguments to `lathe` and its parent functions allowing for start and end angles to be defined but defaulting to the complete circle if they are not specified.
I could also understand if instead the creation of an additional `partialLathe` method is desired, especially if complexity of the partial lathe implementation starts to grow.

### Should the meshes be made watertight?
The current implementation will not close of the start and end face of the lathe if a whole rotation is not achieved as seen below.

<img width="50%" src="https://github.com/user-attachments/assets/683deefc-046b-4385-8c36-1e6c382f624b">

- Is this desirable?
- Should we close these gaps in the mesh by default?
- Should the user be able to choose which behaviour is desired?

I hope this is a good starting point for discussion. If you have any further requirements / ideas please reach out and i will try to implement them.

If the functionality is not desired feel free to close the PR instead.

Best Regards
Kolya